### PR TITLE
ci: enable uv dependency caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,11 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

- Adds `enable-cache: true` to the `astral-sh/setup-uv` step so the uv package cache persists between CI runs
- Adds `cache-dependency-glob` pointing to `pyproject.toml` and `uv.lock` so the cache invalidates correctly when dependencies change

Closes #4

## Test plan

- [ ] Verify CI run completes successfully
- [ ] Compare run times before/after to confirm reduced install time

🤖 Generated with [Claude Code](https://claude.com/claude-code)