### PR TITLE
ci: enforce conventional commit format on PR titles

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,20 @@
+name: PR Title Lint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `amannn/action-semantic-pull-request@v5` to lint PR titles
- Triggers on open, edit, sync, and reopen events
- Required so release-please can parse commits for accurate changelogs and version bumps

## Test plan

- [ ] Open a PR with a non-conventional title and confirm the check fails
- [ ] Fix the title and confirm the check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)