### PR TITLE
ci: add macOS runner for MLX test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main", "dev" ]
 
 jobs:
-  test:
+  test-linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -38,5 +38,32 @@ jobs:
           uv run ruff format --check .
 
       - name: Test with pytest
-        run: |
-          uv run pytest tests/
+        run: uv run pytest tests/
+
+  test-macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Test with pytest
+        run: uv run pytest tests/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,12 +11,12 @@ Open an issue on GitHub with:
 
 ## Pull Requests
 
-1. Fork the repo and create a branch from `main`.
+1. Fork the repo and create a branch from `dev`.
 2. Install dev dependencies: `uv sync --group dev`
 3. Make your changes.
 4. Run the test suite: `uv run pytest tests/`
 5. Run the linter: `uv run ruff check . && uv run ruff format .`
-6. Open a PR against `main` with a clear description of the change.
+6. Open a PR against `dev` with a clear description of the change.
 
 ## Code Style
 
@@ -46,6 +46,18 @@ uv run pytest tests/test_forward_pass_equivalence.py
 # Filter by name
 uv run pytest tests/ -k "test_identity_mapping"
 ```
+
+## CI Matrix
+
+The test suite runs on two separate runner types:
+
+- **Linux (`ubuntu-latest`)**: Covers NumPy, PyTorch, JAX, and TensorFlow across
+  Python 3.10, 3.11, and 3.12. MLX is not installed on Linux (Apple Silicon only).
+- **macOS (`macos-latest`, Apple Silicon)**: Covers all frameworks including MLX,
+  across Python 3.10, 3.11, and 3.12.
+
+If you are contributing MLX changes, verify them locally on Apple Silicon before
+opening a PR.
 
 ## Releasing
 


### PR DESCRIPTION
## Summary

- Splits the single `test` job (ubuntu-only) into `test-linux` and `test-macos` jobs
- `macos-latest` is Apple Silicon, so MLX installs and runs -- closing the gap where MLX tests were silently skipped in CI
- Linting stays on Linux only (no reason to lint twice)
- Fixes `CONTRIBUTING.md` branch instructions (`dev`, not `main`) and adds a CI Matrix section

## Test plan

- [ ] CI shows two job groups: `test-linux` (3 runs) and `test-macos` (3 runs) = 6 total
- [ ] `test-macos` jobs install MLX and run MLX tests (not skipped/xfailed due to missing import)
- [ ] `test-linux` jobs pass without MLX errors

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)