### PR TITLE
fix(tests): use Haar-uniform rotation sampler and add ND recovery tests

### DIFF
--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -29,15 +29,10 @@ def point_clouds_3d(draw, n_points=None):
 def aligned_pair_3d(draw):
     """P + known proper rotation + translation = Q."""
     P = draw(point_clouds_3d())
-    A = draw(
-        arrays(
-            np.float64,
-            (3, 3),
-            elements=st.floats(-1, 1, allow_nan=False, allow_infinity=False),
-        )
-    )
-    # QR decomposition gives a Haar-uniform rotation; offset avoids singular A
-    Q_mat, _ = np.linalg.qr(A + np.eye(3) * 0.1)
+    seed = draw(st.integers(0, 2**31 - 1))
+    A = np.random.default_rng(seed).standard_normal((3, 3))
+    # QR of standard-normal matrix gives Haar-uniform rotation
+    Q_mat, _ = np.linalg.qr(A)
     if np.linalg.det(Q_mat) < 0:
         Q_mat[:, 0] *= -1
     t = draw(
@@ -56,14 +51,10 @@ def aligned_pair_nd(draw):
     """N-D version for kabsch/umeyama."""
     dim = draw(st.integers(2, 6))
     P = draw(point_clouds_nd(dim=dim))
-    A = draw(
-        arrays(
-            np.float64,
-            (dim, dim),
-            elements=st.floats(-1, 1, allow_nan=False, allow_infinity=False),
-        )
-    )
-    Q_mat, _ = np.linalg.qr(A + np.eye(dim) * 0.1)
+    seed = draw(st.integers(0, 2**31 - 1))
+    A = np.random.default_rng(seed).standard_normal((dim, dim))
+    # QR of standard-normal matrix gives Haar-uniform rotation
+    Q_mat, _ = np.linalg.qr(A)
     if np.linalg.det(Q_mat) < 0:
         Q_mat[:, 0] *= -1
     t = draw(

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -3,7 +3,12 @@ import pytest
 from adapters import FrameworkAdapter, frameworks
 from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
-from strategies import aligned_pair_3d, point_clouds_3d, point_clouds_nd
+from strategies import (
+    aligned_pair_3d,
+    aligned_pair_nd,
+    point_clouds_3d,
+    point_clouds_nd,
+)
 
 from kabsch_horn import numpy as kabsch_np
 
@@ -204,3 +209,57 @@ class TestAlignmentOptimality:
         )
 
         assert float(rmsd_opt) <= rmsd_perturbed + 1e-6
+
+
+class TestKabschRecoveryND:
+    """Verify that kabsch/umeyama recover a known rotation across all frameworks."""
+
+    @_FRAMEWORK_SETTINGS
+    @given(aligned_pair_nd())
+    @pytest.mark.parametrize("adapter", frameworks)
+    def test_kabsch_recovers_known_rotation_nd(
+        self, adapter: FrameworkAdapter, aligned: tuple
+    ) -> None:
+        P_np, R_true, t_true, Q_np, dim = aligned
+        if not adapter.supports_dim(dim):
+            return
+        sv = np.linalg.svd(P_np - P_np.mean(0), compute_uv=False)
+        assume(sv[-1] > 1e-3)
+        P = adapter.convert_in(P_np)
+        Q = adapter.convert_in(Q_np)
+        R, t, rmsd = adapter.kabsch(P, Q)
+        R = adapter.convert_out(R)
+        t = adapter.convert_out(t)
+        np.testing.assert_allclose(R, R_true, atol=adapter.atol * 100)
+        np.testing.assert_allclose(t, t_true, atol=adapter.atol * 100)
+        np.testing.assert_allclose(
+            float(adapter.convert_out(rmsd)), 0.0, atol=adapter.atol * 100
+        )
+
+    @_FRAMEWORK_SETTINGS
+    @given(aligned_pair_nd())
+    @pytest.mark.parametrize("adapter", frameworks)
+    def test_kabsch_umeyama_recovers_known_rotation_nd(
+        self, adapter: FrameworkAdapter, aligned: tuple
+    ) -> None:
+        P_np, R_true, t_true, Q_np, dim = aligned
+        if not adapter.supports_dim(dim):
+            return
+        P_c = P_np - P_np.mean(0)
+        # Rotation and scale are recoverable only when the cloud spans all dimensions
+        # with sufficient spread; use a strict singular-value threshold
+        sv = np.linalg.svd(P_c, compute_uv=False)
+        assume(sv[-1] > 1e-3)
+        P = adapter.convert_in(P_np)
+        Q = adapter.convert_in(Q_np)
+        R, t, c, rmsd = adapter.kabsch_umeyama(P, Q)
+        R = adapter.convert_out(R)
+        t = adapter.convert_out(t)
+        np.testing.assert_allclose(R, R_true, atol=adapter.atol * 100)
+        np.testing.assert_allclose(t, t_true, atol=adapter.atol * 100)
+        np.testing.assert_allclose(
+            float(adapter.convert_out(c)), 1.0, atol=adapter.atol * 100
+        )
+        np.testing.assert_allclose(
+            float(adapter.convert_out(rmsd)), 0.0, atol=adapter.atol * 100
+        )


### PR DESCRIPTION
## Summary

- Replace biased `uniform[-1,1] + 0.1*I` QR sampler in `aligned_pair_3d` and `aligned_pair_nd` with `np.random.default_rng(seed).standard_normal(...)`, which produces truly Haar-uniform rotations (QR of a standard-normal matrix is Haar-distributed; the old approach was biased toward identity)
- Add `TestKabschRecoveryND` class with two property tests parametrized over all 16 framework/precision adapters:
  - `test_kabsch_recovers_known_rotation_nd` -- verifies `kabsch` recovers R, t, and rmsd≈0
  - `test_kabsch_umeyama_recovers_known_rotation_nd` -- same for `kabsch_umeyama`, additionally checks scale c≈1
- Both new tests use `sv[-1] > 1e-3` (smallest singular value of centered P) as the degeneracy guard, stricter than `matrix_rank` alone

Closes #10

## Test plan

- [x] `uv run pytest tests/test_properties.py -v -k "recovery"` -- 32 passed
- [x] `uv run pytest tests/test_properties.py -v` -- 148 passed
- [x] `uv run ruff check tests/strategies.py tests/test_properties.py` -- no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)