### PR TITLE
fix: correct GitHub username in pyproject.toml URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,10 @@ classifiers = [
 dependencies = []
 
 [project.urls]
-Homepage = "https://github.com/heidenreich/Kabsch-Cookbook"
-Repository = "https://github.com/heidenreich/Kabsch-Cookbook"
-Issues = "https://github.com/heidenreich/Kabsch-Cookbook/issues"
-Changelog = "https://github.com/heidenreich/Kabsch-Cookbook/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/hunter-heidenreich/Kabsch-Cookbook"
+Repository = "https://github.com/hunter-heidenreich/Kabsch-Cookbook"
+Issues = "https://github.com/hunter-heidenreich/Kabsch-Cookbook/issues"
+Changelog = "https://github.com/hunter-heidenreich/Kabsch-Cookbook/blob/main/CHANGELOG.md"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary
- Replaces `heidenreich` with `hunter-heidenreich` in all four `[project.urls]` entries in `pyproject.toml`
- Fixes 404s on the PyPI project page for Homepage, Repository, Issues, and Changelog links

Closes #32.

## Test plan
- [ ] Verify the four URLs in `pyproject.toml` resolve correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)