### PR TITLE
fix: wrap numpy imports in try/except like all other backends

### DIFF
--- a/src/kabsch_horn/__init__.py
+++ b/src/kabsch_horn/__init__.py
@@ -1,11 +1,13 @@
 """Kabsch-Umeyama Algorithm Implementation across Frameworks."""
 
-from .numpy.horn_quat_3d import horn as horn_numpy
-from .numpy.horn_quat_3d import horn_with_scale as horn_with_scale_numpy
-from .numpy.kabsch_svd_nd import kabsch as kabsch_numpy
-from .numpy.kabsch_svd_nd import kabsch_umeyama as kabsch_umeyama_numpy
-
 # Attempt to load backends, fallback silently if not present
+try:
+    from .numpy.horn_quat_3d import horn as horn_numpy
+    from .numpy.horn_quat_3d import horn_with_scale as horn_with_scale_numpy
+    from .numpy.kabsch_svd_nd import kabsch as kabsch_numpy
+    from .numpy.kabsch_svd_nd import kabsch_umeyama as kabsch_umeyama_numpy
+except ImportError:
+    pass
 try:
     from .pytorch.horn_quat_3d import horn as horn_torch
     from .pytorch.horn_quat_3d import horn_with_scale as horn_with_scale_torch


### PR DESCRIPTION
## Summary
- Fixes #39: `numpy` was imported unconditionally in `src/kabsch_horn/__init__.py`, causing `ImportError` for users installing without dev extras (`pip install kabsch-horn-cookbook`)
- Wraps the four numpy imports in `try/except ImportError: pass`, consistent with pytorch, jax, tensorflow, and mlx
- No changes to `pyproject.toml` (numpy stays as a dev dependency) or `__all__`

## Test plan
- [x] `uv run pytest tests/` passes -- 5722 passed, 160 skipped (numpy present in dev env)
- [x] `python -c "import kabsch_horn"` succeeds in a fresh venv with no frameworks installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)