### PR TITLE
refactor(tests): add kabsch_rmsd/umeyama_rmsd to FrameworkAdapter and clean up dispatch

### DIFF
--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -71,6 +71,12 @@ class FrameworkAdapter(Generic[T]):
     def horn_with_scale(self, P: T, Q: T) -> tuple[T, ...]:
         raise NotImplementedError
 
+    def kabsch_rmsd(self, P: T, Q: T) -> T:
+        raise NotImplementedError
+
+    def kabsch_umeyama_rmsd(self, P: T, Q: T) -> T:
+        raise NotImplementedError
+
     def get_transform_func(self, algo: str) -> Callable[[T, T], tuple[T, ...]]:
         """Returns the corresponding transformation function for the given algorithm."""
         if algo == "kabsch":
@@ -136,6 +142,12 @@ class PyTorchAdapter(FrameworkAdapter[torch.Tensor]):
         self, P: torch.Tensor, Q: torch.Tensor
     ) -> tuple[torch.Tensor, ...]:
         return kabsch_torch.horn_with_scale(P, Q)
+
+    def kabsch_rmsd(self, P: torch.Tensor, Q: torch.Tensor) -> torch.Tensor:
+        return kabsch_torch.kabsch_rmsd(P, Q)
+
+    def kabsch_umeyama_rmsd(self, P: torch.Tensor, Q: torch.Tensor) -> torch.Tensor:
+        return kabsch_torch.kabsch_umeyama_rmsd(P, Q)
 
     def is_nan(self, tensor: torch.Tensor) -> bool:
         return torch.isnan(tensor).any().item()
@@ -204,6 +216,12 @@ class JAXAdapter(FrameworkAdapter[jax.Array]):
 
     def horn_with_scale(self, P: jax.Array, Q: jax.Array) -> tuple[jax.Array, ...]:
         return kabsch_jax.horn_with_scale(P, Q)
+
+    def kabsch_rmsd(self, P: jax.Array, Q: jax.Array) -> jax.Array:
+        return kabsch_jax.kabsch_rmsd(P, Q)
+
+    def kabsch_umeyama_rmsd(self, P: jax.Array, Q: jax.Array) -> jax.Array:
+        return kabsch_jax.kabsch_umeyama_rmsd(P, Q)
 
     def is_nan(self, tensor: jax.Array) -> bool:
         return jnp.isnan(tensor).any()
@@ -280,6 +298,16 @@ class TFAdapter(FrameworkAdapter[tf.Tensor | tf.Variable]):
         self, P: tf.Tensor | tf.Variable, Q: tf.Tensor | tf.Variable
     ) -> tuple[tf.Tensor | tf.Variable, ...]:
         return kabsch_tf.horn_with_scale(P, Q)
+
+    def kabsch_rmsd(
+        self, P: tf.Tensor | tf.Variable, Q: tf.Tensor | tf.Variable
+    ) -> tf.Tensor | tf.Variable:
+        return kabsch_tf.kabsch_rmsd(P, Q)
+
+    def kabsch_umeyama_rmsd(
+        self, P: tf.Tensor | tf.Variable, Q: tf.Tensor | tf.Variable
+    ) -> tf.Tensor | tf.Variable:
+        return kabsch_tf.kabsch_umeyama_rmsd(P, Q)
 
     def is_nan(self, tensor: tf.Tensor | tf.Variable) -> bool:
         return tf.math.is_nan(tensor).numpy().any()
@@ -377,6 +405,14 @@ if _MLX_AVAILABLE:
         def horn_with_scale(self, P: mx.array, Q: mx.array) -> tuple[mx.array, ...]:
             self._set_device()
             return kabsch_mlx.horn_with_scale(P, Q)
+
+        def kabsch_rmsd(self, P: mx.array, Q: mx.array) -> mx.array:
+            self._set_device()
+            return kabsch_mlx.kabsch_rmsd(P, Q)
+
+        def kabsch_umeyama_rmsd(self, P: mx.array, Q: mx.array) -> mx.array:
+            self._set_device()
+            return kabsch_mlx.kabsch_umeyama_rmsd(P, Q)
 
         def is_nan(self, tensor: mx.array) -> bool:
             self._set_device()

--- a/tests/test_rmsd_wrappers.py
+++ b/tests/test_rmsd_wrappers.py
@@ -26,27 +26,8 @@ class TestKabschRmsdWrappers:
         P = adapter.convert_in(P_np)
         Q = adapter.convert_in(Q_np)
 
-        from kabsch_horn import jax as kabsch_jax
-        from kabsch_horn import pytorch as kabsch_torch
-        from kabsch_horn import tensorflow as kabsch_tf
-
-        adapter_cls = type(adapter).__name__
-        if adapter_cls == "PyTorchAdapter":
-            rmsd_wrapper = float(adapter.convert_out(kabsch_torch.kabsch_rmsd(P, Q)))
-            rmsd_full = float(adapter.convert_out(kabsch_torch.kabsch(P, Q)[2]))
-        elif adapter_cls == "JAXAdapter":
-            rmsd_wrapper = float(adapter.convert_out(kabsch_jax.kabsch_rmsd(P, Q)))
-            rmsd_full = float(adapter.convert_out(kabsch_jax.kabsch(P, Q)[2]))
-        elif adapter_cls == "TFAdapter":
-            rmsd_wrapper = float(adapter.convert_out(kabsch_tf.kabsch_rmsd(P, Q)))
-            rmsd_full = float(adapter.convert_out(kabsch_tf.kabsch(P, Q)[2]))
-        elif adapter_cls == "MLXAdapter":
-            from kabsch_horn import mlx as kabsch_mlx
-
-            rmsd_wrapper = float(adapter.convert_out(kabsch_mlx.kabsch_rmsd(P, Q)))
-            rmsd_full = float(adapter.convert_out(kabsch_mlx.kabsch(P, Q)[2]))
-        else:
-            pytest.skip(f"Unsupported adapter: {adapter_cls}")
+        rmsd_wrapper = float(adapter.convert_out(adapter.kabsch_rmsd(P, Q)))
+        rmsd_full = float(adapter.convert_out(adapter.kabsch(P, Q)[2]))
 
         assert rmsd_wrapper == pytest.approx(
             rmsd_full, rel=adapter.rtol, abs=adapter.atol
@@ -67,27 +48,8 @@ class TestKabschRmsdWrappers:
         P = adapter.convert_in(P_np)
         Q = adapter.convert_in(Q_np)
 
-        from kabsch_horn import jax as kabsch_jax
-        from kabsch_horn import pytorch as kabsch_torch
-        from kabsch_horn import tensorflow as kabsch_tf
-
-        adapter_cls = type(adapter).__name__
-        if adapter_cls == "PyTorchAdapter":
-            rmsd_w = float(adapter.convert_out(kabsch_torch.kabsch_umeyama_rmsd(P, Q)))
-            rmsd_f = float(adapter.convert_out(kabsch_torch.kabsch_umeyama(P, Q)[3]))
-        elif adapter_cls == "JAXAdapter":
-            rmsd_w = float(adapter.convert_out(kabsch_jax.kabsch_umeyama_rmsd(P, Q)))
-            rmsd_f = float(adapter.convert_out(kabsch_jax.kabsch_umeyama(P, Q)[3]))
-        elif adapter_cls == "TFAdapter":
-            rmsd_w = float(adapter.convert_out(kabsch_tf.kabsch_umeyama_rmsd(P, Q)))
-            rmsd_f = float(adapter.convert_out(kabsch_tf.kabsch_umeyama(P, Q)[3]))
-        elif adapter_cls == "MLXAdapter":
-            from kabsch_horn import mlx as kabsch_mlx
-
-            rmsd_w = float(adapter.convert_out(kabsch_mlx.kabsch_umeyama_rmsd(P, Q)))
-            rmsd_f = float(adapter.convert_out(kabsch_mlx.kabsch_umeyama(P, Q)[3]))
-        else:
-            pytest.skip(f"Unsupported adapter: {adapter_cls}")
+        rmsd_w = float(adapter.convert_out(adapter.kabsch_umeyama_rmsd(P, Q)))
+        rmsd_f = float(adapter.convert_out(adapter.kabsch_umeyama(P, Q)[3]))
 
         assert rmsd_w == pytest.approx(rmsd_f, rel=adapter.rtol, abs=adapter.atol)
 
@@ -119,36 +81,10 @@ class TestKabschRmsdWrappers:
         P = adapter.convert_in(P_np)
         Q = adapter.convert_in(Q_np)
 
-        from kabsch_horn import jax as kabsch_jax
-        from kabsch_horn import pytorch as kabsch_torch
-        from kabsch_horn import tensorflow as kabsch_tf
-
-        adapter_cls = type(adapter).__name__
-        if adapter_cls == "PyTorchAdapter":
-            func_map = {
-                "kabsch_rmsd": kabsch_torch.kabsch_rmsd,
-                "kabsch_umeyama_rmsd": kabsch_torch.kabsch_umeyama_rmsd,
-            }
-        elif adapter_cls == "JAXAdapter":
-            func_map = {
-                "kabsch_rmsd": kabsch_jax.kabsch_rmsd,
-                "kabsch_umeyama_rmsd": kabsch_jax.kabsch_umeyama_rmsd,
-            }
-        elif adapter_cls == "TFAdapter":
-            func_map = {
-                "kabsch_rmsd": kabsch_tf.kabsch_rmsd,
-                "kabsch_umeyama_rmsd": kabsch_tf.kabsch_umeyama_rmsd,
-            }
-        elif adapter_cls == "MLXAdapter":
-            from kabsch_horn import mlx as kabsch_mlx
-
-            func_map = {
-                "kabsch_rmsd": kabsch_mlx.kabsch_rmsd,
-                "kabsch_umeyama_rmsd": kabsch_mlx.kabsch_umeyama_rmsd,
-            }
-        else:
-            pytest.skip(f"Unsupported adapter: {adapter_cls}")
-
+        func_map = {
+            "kabsch_rmsd": adapter.kabsch_rmsd,
+            "kabsch_umeyama_rmsd": adapter.kabsch_umeyama_rmsd,
+        }
         rmsd = float(adapter.convert_out(func_map[algo](P, Q)))
         assert rmsd == pytest.approx(0.0, abs=adapter.atol)
 
@@ -170,43 +106,38 @@ class TestKabschRmsdWrappers:
         P = adapter.convert_in(P_np)
         Q = adapter.convert_in(Q_np)
 
-        from kabsch_horn import jax as kabsch_jax
-        from kabsch_horn import pytorch as kabsch_torch
-        from kabsch_horn import tensorflow as kabsch_tf
-
-        adapter_cls = type(adapter).__name__
-        if adapter_cls == "PyTorchAdapter":
-            func_map = {
-                "kabsch_rmsd": kabsch_torch.kabsch_rmsd,
-                "kabsch_umeyama_rmsd": kabsch_torch.kabsch_umeyama_rmsd,
-            }
-        elif adapter_cls == "JAXAdapter":
-            func_map = {
-                "kabsch_rmsd": kabsch_jax.kabsch_rmsd,
-                "kabsch_umeyama_rmsd": kabsch_jax.kabsch_umeyama_rmsd,
-            }
-        elif adapter_cls == "TFAdapter":
-            func_map = {
-                "kabsch_rmsd": kabsch_tf.kabsch_rmsd,
-                "kabsch_umeyama_rmsd": kabsch_tf.kabsch_umeyama_rmsd,
-            }
-        elif adapter_cls == "MLXAdapter":
-            from kabsch_horn import mlx as kabsch_mlx
-
-            func_map = {
-                "kabsch_rmsd": kabsch_mlx.kabsch_rmsd,
-                "kabsch_umeyama_rmsd": kabsch_mlx.kabsch_umeyama_rmsd,
-            }
-        else:
-            pytest.skip(f"Unsupported adapter: {adapter_cls}")
-
-        rmsd_fn = func_map[algo]
+        rmsd_fn = getattr(adapter, algo)
 
         def wrapper(P_inner, Q_inner):
             return (rmsd_fn(P_inner, Q_inner),)
 
         grad = adapter.get_grad(P, Q, wrapper, seed=None, wrt="P")
         assert np.isfinite(grad).all(), "Gradient from rmsd wrapper contains NaN/Inf"
+
+    @pytest.mark.parametrize("algo", ["kabsch_rmsd", "kabsch_umeyama_rmsd"])
+    @pytest.mark.parametrize("adapter", frameworks)
+    def test_rmsd_wrapper_gradient_wrt_q_is_finite(
+        self,
+        adapter: FrameworkAdapter,
+        algo: str,
+    ) -> None:
+        """Gradients wrt Q from rmsd wrappers are finite."""
+        rng = np.random.default_rng(4)
+        P_np = rng.random((20, 3))
+        Q_np = rng.random((20, 3))
+
+        P = adapter.convert_in(P_np)
+        Q = adapter.convert_in(Q_np)
+
+        rmsd_fn = getattr(adapter, algo)
+
+        def wrapper(P_inner, Q_inner):
+            return (rmsd_fn(P_inner, Q_inner),)
+
+        grad = adapter.get_grad(P, Q, wrapper, seed=None, wrt="Q")
+        assert np.isfinite(grad).all(), (
+            "Gradient wrt Q from rmsd wrapper contains NaN/Inf"
+        )
 
 
 class TestSinglePoint:


### PR DESCRIPTION
## Summary

- Adds `kabsch_rmsd` and `kabsch_umeyama_rmsd` methods to `FrameworkAdapter` base class and all four framework subclasses (`PyTorchAdapter`, `JAXAdapter`, `TFAdapter`, `MLXAdapter`)
- Replaces every 4-branch `adapter_cls` dispatch block in `test_rmsd_wrappers.py` with direct `adapter.kabsch_rmsd()` / `adapter.kabsch_umeyama_rmsd()` calls
- Removes now-unused inline `from kabsch_horn import ...` imports inside test methods
- Adds `test_rmsd_wrapper_gradient_wrt_q_is_finite` -- 32 new parametrized cases covering `wrt="Q"` gradient finitude across all frameworks and precisions

Closes #18, #37

## Test plan

- [x] `uv run pytest tests/test_rmsd_wrappers.py -v` -- 160/160 passed
- [x] `uv run ruff check tests/adapters.py tests/test_rmsd_wrappers.py` -- no issues
- [x] `uv run ruff format --check tests/adapters.py tests/test_rmsd_wrappers.py` -- already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)