### PR TITLE
fix: build __all__ dynamically inside each try block

### DIFF
--- a/src/kabsch_horn/__init__.py
+++ b/src/kabsch_horn/__init__.py
@@ -1,13 +1,23 @@
 """Kabsch-Umeyama Algorithm Implementation across Frameworks."""
 
+__all__: list[str] = []
+
 # Attempt to load backends, fallback silently if not present
 try:
     from .numpy.horn_quat_3d import horn as horn_numpy
     from .numpy.horn_quat_3d import horn_with_scale as horn_with_scale_numpy
     from .numpy.kabsch_svd_nd import kabsch as kabsch_numpy
     from .numpy.kabsch_svd_nd import kabsch_umeyama as kabsch_umeyama_numpy
+
+    __all__ += [
+        "horn_numpy",
+        "horn_with_scale_numpy",
+        "kabsch_numpy",
+        "kabsch_umeyama_numpy",
+    ]
 except ImportError:
     pass
+
 try:
     from .pytorch.horn_quat_3d import horn as horn_torch
     from .pytorch.horn_quat_3d import horn_with_scale as horn_with_scale_torch
@@ -17,6 +27,15 @@ try:
     from .pytorch.kabsch_svd_nd import (
         kabsch_umeyama_rmsd as kabsch_umeyama_rmsd_torch,
     )
+
+    __all__ += [
+        "horn_torch",
+        "horn_with_scale_torch",
+        "kabsch_rmsd_torch",
+        "kabsch_torch",
+        "kabsch_umeyama_rmsd_torch",
+        "kabsch_umeyama_torch",
+    ]
 except ImportError:
     pass
 
@@ -29,6 +48,15 @@ try:
     from .jax.kabsch_svd_nd import (
         kabsch_umeyama_rmsd as kabsch_umeyama_rmsd_jax,
     )
+
+    __all__ += [
+        "horn_jax",
+        "horn_with_scale_jax",
+        "kabsch_jax",
+        "kabsch_rmsd_jax",
+        "kabsch_umeyama_jax",
+        "kabsch_umeyama_rmsd_jax",
+    ]
 except ImportError:
     pass
 
@@ -41,6 +69,15 @@ try:
     from .tensorflow.kabsch_svd_nd import (
         kabsch_umeyama_rmsd as kabsch_umeyama_rmsd_tf,
     )
+
+    __all__ += [
+        "horn_tf",
+        "horn_with_scale_tf",
+        "kabsch_rmsd_tf",
+        "kabsch_tf",
+        "kabsch_umeyama_rmsd_tf",
+        "kabsch_umeyama_tf",
+    ]
 except ImportError:
     pass
 
@@ -53,36 +90,14 @@ try:
     from .mlx.kabsch_svd_nd import (
         kabsch_umeyama_rmsd as kabsch_umeyama_rmsd_mlx,
     )
+
+    __all__ += [
+        "horn_mlx",
+        "horn_with_scale_mlx",
+        "kabsch_mlx",
+        "kabsch_rmsd_mlx",
+        "kabsch_umeyama_mlx",
+        "kabsch_umeyama_rmsd_mlx",
+    ]
 except ImportError:
     pass
-
-__all__ = [
-    "horn_jax",
-    "horn_mlx",
-    "horn_numpy",
-    "horn_tf",
-    "horn_torch",
-    "horn_with_scale_jax",
-    "horn_with_scale_mlx",
-    "horn_with_scale_numpy",
-    "horn_with_scale_tf",
-    "horn_with_scale_torch",
-    "kabsch_jax",
-    "kabsch_mlx",
-    "kabsch_numpy",
-    "kabsch_rmsd_jax",
-    "kabsch_rmsd_mlx",
-    "kabsch_rmsd_tf",
-    "kabsch_rmsd_torch",
-    "kabsch_tf",
-    "kabsch_torch",
-    "kabsch_umeyama_jax",
-    "kabsch_umeyama_mlx",
-    "kabsch_umeyama_numpy",
-    "kabsch_umeyama_rmsd_jax",
-    "kabsch_umeyama_rmsd_mlx",
-    "kabsch_umeyama_rmsd_tf",
-    "kabsch_umeyama_rmsd_torch",
-    "kabsch_umeyama_tf",
-    "kabsch_umeyama_torch",
-]


### PR DESCRIPTION
## Summary

- `__all__` was a static list containing every framework symbol unconditionally
- If any framework (torch, jax, tf, mlx) was not installed, `from kabsch_horn import *` raised `AttributeError` despite the package being designed to degrade gracefully
- Each symbol is now appended to `__all__` inside its own `try` block, so only installed frameworks appear in `__all__`

Closes #45

## Test plan

- [ ] CI passes on Linux and macOS
- [ ] `from kabsch_horn import *` works when only a subset of frameworks is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)