### PR TITLE
fix: consistent shape validation before auto-batching across all frameworks

### DIFF
--- a/src/kabsch_horn/jax/kabsch_svd_nd.py
+++ b/src/kabsch_horn/jax/kabsch_svd_nd.py
@@ -100,6 +100,11 @@ def kabsch(
         (R, t, rmsd): Rotation [..., D, D], translation [..., D], and RMSD [...].
         float16/bfloat16 inputs are upcast to float32 internally and downcast on output.
     """
+    if P.shape != Q.shape:
+        raise ValueError(
+            f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
+        )
+
     orig_dtype = P.dtype
     if orig_dtype in (jnp.float16, jnp.bfloat16):
         P = P.astype(jnp.float32)
@@ -182,6 +187,11 @@ def kabsch_umeyama(
         scale [...], RMSD [...].
         float16/bfloat16 inputs are upcast to float32 and downcast on output.
     """
+    if P.shape != Q.shape:
+        raise ValueError(
+            f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
+        )
+
     orig_dtype = P.dtype
     if orig_dtype in (jnp.float16, jnp.bfloat16):
         P = P.astype(jnp.float32)

--- a/src/kabsch_horn/mlx/kabsch_svd_nd.py
+++ b/src/kabsch_horn/mlx/kabsch_svd_nd.py
@@ -82,6 +82,11 @@ def kabsch(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
     Raises:
         ValueError: If inputs are not 3-dimensional (D != 3).
     """
+    if P.shape != Q.shape:
+        raise ValueError(
+            f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
+        )
+
     if P.shape[-1] != 3:
         raise ValueError(
             f"MLX Kabsch only supports dim=3, got dim={P.shape[-1]}. "
@@ -181,6 +186,11 @@ def kabsch_umeyama(
     Raises:
         ValueError: If inputs are not 3-dimensional (D != 3).
     """
+    if P.shape != Q.shape:
+        raise ValueError(
+            f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
+        )
+
     if P.shape[-1] != 3:
         raise ValueError(
             f"MLX Kabsch only supports dim=3, got dim={P.shape[-1]}. "

--- a/src/kabsch_horn/numpy/kabsch_svd_nd.py
+++ b/src/kabsch_horn/numpy/kabsch_svd_nd.py
@@ -12,16 +12,16 @@ def kabsch(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.nda
     Returns:
         (R, t, rmsd): Optimal rotation (Bx3x3), translation (Bx3), and RMSD.
     """
+    if P.shape != Q.shape:
+        raise ValueError(
+            f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
+        )
+
     # Auto-batch single elements
     is_single = P.ndim == 2
     if is_single:
         P = P[np.newaxis, ...]
         Q = Q[np.newaxis, ...]
-
-    if P.shape != Q.shape:
-        raise ValueError(
-            f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
-        )
 
     orig_shape = P.shape
     batch_dims = orig_shape[:-2]
@@ -94,15 +94,15 @@ def kabsch_umeyama(
         (R, t, c, rmsd): Optimal rotation (Bx3x3), translation (Bx3), scale factor (B),
         and RMSD.
     """
-    is_single = P.ndim == 2
-    if is_single:
-        P = P[np.newaxis, ...]
-        Q = Q[np.newaxis, ...]
-
     if P.shape != Q.shape:
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
         )
+
+    is_single = P.ndim == 2
+    if is_single:
+        P = P[np.newaxis, ...]
+        Q = Q[np.newaxis, ...]
 
     orig_shape = P.shape
     batch_dims = orig_shape[:-2]

--- a/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
+++ b/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
@@ -71,6 +71,11 @@ def kabsch(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]
     """
     Computes the optimal rotation and translation to align P and Q.
     """
+    if P.shape != Q.shape:
+        raise ValueError(
+            f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
+        )
+
     orig_dtype = P.dtype
     if orig_dtype in (tf.float16, tf.bfloat16):
         P = tf.cast(P, tf.float32)
@@ -142,6 +147,11 @@ def kabsch_umeyama(
     """
     Computes the optimal rotation, translation, and scale.
     """
+    if P.shape != Q.shape:
+        raise ValueError(
+            f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
+        )
+
     orig_dtype = P.dtype
     if orig_dtype in (tf.float16, tf.bfloat16):
         P = tf.cast(P, tf.float32)

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -362,7 +362,7 @@ try:
         def mismatch_exception_type(
             self,
         ) -> type[Exception] | tuple[type[Exception], ...]:
-            return tf.errors.InvalidArgumentError
+            return (tf.errors.InvalidArgumentError, ValueError)
 
 except ImportError:
     _TF_AVAILABLE = False


### PR DESCRIPTION
## Summary

- numpy: moved `P.shape != Q.shape` check before the auto-batching unsqueeze, so error messages reflect the caller's original shape
- jax: added the same shape check before unsqueeze (was missing entirely)
- tensorflow: added shape check at function entry (no auto-batching, but check was absent)
- mlx: added shape check at function entry before the dim=3 guard (was absent)
- `tests/adapters.py`: updated TF adapter's `mismatch_exception_type` to include `ValueError` alongside `tf.errors.InvalidArgumentError`

Applies to both `kabsch` and `kabsch_umeyama` in each framework.

Fixes #49

## Test plan

- [x] All existing tests pass (two pre-existing failures in `test_properties.py` on `dev` are unrelated)
- [x] `test_raises_error_when_point_counts_differ` passes for all frameworks and precisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)