### PR TITLE
fix: remove dead _B = P.shape[0] assignments across all frameworks

### DIFF
--- a/src/kabsch_horn/jax/kabsch_svd_nd.py
+++ b/src/kabsch_horn/jax/kabsch_svd_nd.py
@@ -123,8 +123,6 @@ def kabsch(
     P = P.reshape(-1, N, D)
     Q = Q.reshape(-1, N, D)
 
-    _B = P.shape[0]
-
     centroid_P = jnp.mean(P, axis=1, keepdims=True)
     centroid_Q = jnp.mean(Q, axis=1, keepdims=True)
 
@@ -209,8 +207,6 @@ def kabsch_umeyama(
 
     P = P.reshape(-1, N, D)
     Q = Q.reshape(-1, N, D)
-
-    _B = P.shape[0]
 
     centroid_P = jnp.mean(P, axis=1, keepdims=True)
     centroid_Q = jnp.mean(Q, axis=1, keepdims=True)

--- a/src/kabsch_horn/numpy/kabsch_svd_nd.py
+++ b/src/kabsch_horn/numpy/kabsch_svd_nd.py
@@ -111,8 +111,6 @@ def kabsch_umeyama(
     P = np.reshape(P, (-1, N, D))
     Q = np.reshape(Q, (-1, N, D))
 
-    _B = P.shape[0]
-
     # Compute centroids
     centroid_P = np.mean(P, axis=1, keepdims=True)  # Bx1xD
     centroid_Q = np.mean(Q, axis=1, keepdims=True)  # Bx1xD

--- a/src/kabsch_horn/pytorch/kabsch_svd_nd.py
+++ b/src/kabsch_horn/pytorch/kabsch_svd_nd.py
@@ -139,8 +139,6 @@ def kabsch(
     P = P.view(-1, _N, D)
     Q = Q.view(-1, _N, D)
 
-    _B = P.shape[0]
-
     # Compute centroids
     centroid_P = torch.mean(P, dim=1, keepdim=True)  # Bx1x3
     centroid_Q = torch.mean(Q, dim=1, keepdim=True)  # Bx1x3
@@ -232,8 +230,6 @@ def kabsch_umeyama(
 
     P = P.view(-1, N, D)
     Q = Q.view(-1, N, D)
-
-    _B = P.shape[0]
 
     # Compute centroids
     centroid_P = torch.mean(P, dim=1, keepdim=True)


### PR DESCRIPTION
## Summary

- Deletes the `_B = P.shape[0]` dead assignment from `numpy/kabsch_svd_nd.py` (kabsch_umeyama), `pytorch/kabsch_svd_nd.py` (kabsch + kabsch_umeyama), and `jax/kabsch_svd_nd.py` (kabsch + kabsch_umeyama)
- The variable was never read after being assigned; the underscore prefix was suppressing lint warnings for purely dead code
- TF and MLX did not have this pattern

## Test plan

- [x] All existing tests pass (2 pre-existing failures in `test_properties.py` unrelated to this change)
- [x] `ruff check` and `ruff format --check` pass

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)