### PR TITLE
fix: enforce NaN-propagation contract in test_propagates_nans_gracefully

### DIFF
--- a/src/kabsch_horn/pytorch/kabsch_svd_nd.py
+++ b/src/kabsch_horn/pytorch/kabsch_svd_nd.py
@@ -14,8 +14,17 @@ class SafeSVD(torch.autograd.Function):
     def forward(
         ctx, A: torch.Tensor, eps: float = 1e-12
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        # Fast path
-        U, S, Vh = torch.linalg.svd(A)
+        try:
+            U, S, Vh = torch.linalg.svd(A)
+        except torch.linalg.LinAlgError:
+            # NaN or degenerate input: propagate NaN without crashing.
+            # torch.linalg.svd raises rather than returning NaN, so we handle
+            # it explicitly to satisfy the NaN-propagation contract.
+            nan_mat = A.new_full(A.shape, float("nan"))
+            nan_s = A.new_full(A.shape[:-1], float("nan"))
+            ctx.save_for_backward(nan_mat, nan_s, nan_mat)
+            ctx.eps = eps
+            return nan_mat, nan_s, nan_mat
         # In PyTorch 1.11+, linalg.svd returns Vh (V^T or V^H).
         # We want V for the standard Kabsch logic, so V = Vh.transpose(-2, -1)
         V = Vh.mH  # Conjugate transpose / standard transpose for real.

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -69,8 +69,11 @@ class TestErrorHandling:
         algo: str,
     ) -> None:
         """
-        Verifies that if inputs contain NaNs, the output contains NaNs without
-        raising hard C-level aborts or failing to track mathematically.
+        Contract: NaN inputs must propagate to NaN outputs without raising exceptions.
+
+        PyTorch, JAX, and TensorFlow all propagate NaN through SVD. A framework
+        that raises on NaN input would be a real test failure here.
+        MLX is excluded because its linalg.svd fatally aborts the process on NaN.
         """
         if adapter.__class__.__name__ == "MLXAdapter":
             pytest.skip(
@@ -94,13 +97,7 @@ class TestErrorHandling:
 
         func = adapter.kabsch_umeyama if algo == "umeyama" else adapter.kabsch
 
-        try:
-            res = func(P, Q)
-        except Exception as e:
-            pytest.skip(
-                "Framework handles NaNs by raising an exception, "
-                f"which is acceptable: {e}"
-            )
+        res = func(P, Q)
 
         for tensor in res:
             if isinstance(tensor, float):


### PR DESCRIPTION
Fixes #42.

## Summary

- `test_propagates_nans_gracefully` had a structural flaw: any exception during the NaN forward pass was silently converted to `pytest.skip`, making the test impossible to fail
- The fix establishes a clear contract: NaN inputs must propagate to NaN outputs without raising exceptions
- The try/except escape hatch is removed; the function is called directly
- Discovered that PyTorch's `torch.linalg.svd` raises `LinAlgError` on NaN input rather than propagating NaN -- fixed in `SafeSVD.forward` by catching that error and returning NaN tensors of the correct shape

## Test plan

- [x] `uv run pytest tests/test_error_handling.py -v -k "test_propagates_nans"` -- 24 passed, 8 skipped (MLX)
- [x] `uv run pytest tests/ -x` -- 5762 passed, 152 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)