### PR TITLE
docs: update numpy docstrings to [..., N, D] shape notation

### DIFF
--- a/src/kabsch_horn/numpy/kabsch_svd_nd.py
+++ b/src/kabsch_horn/numpy/kabsch_svd_nd.py
@@ -91,7 +91,8 @@ def kabsch_umeyama(
         Q: Target points, shape [..., N, D].
 
     Returns:
-        (R, t, c, rmsd): Rotation [..., D, D], translation [..., D], scale [...], RMSD [...].
+        (R, t, c, rmsd): Rotation [..., D, D], translation [..., D], scale [...],
+        RMSD [...].
     """
     if P.shape != Q.shape:
         raise ValueError(

--- a/src/kabsch_horn/numpy/kabsch_svd_nd.py
+++ b/src/kabsch_horn/numpy/kabsch_svd_nd.py
@@ -6,11 +6,11 @@ def kabsch(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.nda
     Computes the optimal rotation and translation to align P to Q.
 
     Args:
-        P: A BxNx3 array or Nx3 array of source points.
-        Q: A BxNx3 array or Nx3 array of target points.
+        P: Source points, shape [..., N, D].
+        Q: Target points, shape [..., N, D].
 
     Returns:
-        (R, t, rmsd): Optimal rotation (Bx3x3), translation (Bx3), and RMSD.
+        (R, t, rmsd): Rotation [..., D, D], translation [..., D], RMSD [...].
     """
     if P.shape != Q.shape:
         raise ValueError(
@@ -87,12 +87,11 @@ def kabsch_umeyama(
     (Q ~ c * R @ P + t).
 
     Args:
-        P: A BxNx3 array or Nx3 array of source points.
-        Q: A BxNx3 array or Nx3 array of target points.
+        P: Source points, shape [..., N, D].
+        Q: Target points, shape [..., N, D].
 
     Returns:
-        (R, t, c, rmsd): Optimal rotation (Bx3x3), translation (Bx3), scale factor (B),
-        and RMSD.
+        (R, t, c, rmsd): Rotation [..., D, D], translation [..., D], scale [...], RMSD [...].
     """
     if P.shape != Q.shape:
         raise ValueError(


### PR DESCRIPTION
## Summary

- Replaces the old `BxNx3` / `Bx3x3` shape descriptions in `kabsch` and `kabsch_umeyama` docstrings with the canonical `[..., N, D]` / `[..., D, D]` notation
- Fixes #48
- No code changes -- docs only

## Test plan

- [ ] Verify docstrings in `src/kabsch_horn/numpy/kabsch_svd_nd.py` now match the style used in `jax/`, `pytorch/`, `tensorflow/`, and `mlx/` modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)