### PR TITLE
fix: add [tool.pytest.ini_options] with testpaths to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [tool.ruff]
 target-version = "py310"
 line-length = 88


### PR DESCRIPTION
## Summary

- Adds `[tool.pytest.ini_options]` section to `pyproject.toml` with `testpaths = ["tests"]`
- Ensures `uv run pytest` (no args) resolves to `tests/` without needing an explicit path argument, consistent with the documented commands in `CLAUDE.md`

Closes #35.

## Test plan

- [x] `uv run pytest` (no args) collects the same 6938 tests as `uv run pytest tests/`
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)