### PR TITLE
fix(ci): replace uv sync --all-extras --dev with uv sync --dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --all-extras --dev
+        run: uv sync --dev
 
       - name: Lint with Ruff
         run: |
@@ -63,7 +63,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --all-extras --dev
+        run: uv sync --dev
 
       - name: Test with pytest
         run: uv run pytest tests/


### PR DESCRIPTION
## Summary

- Removes the `--all-extras` flag from both `test-linux` and `test-macos` install steps in `test.yml`
- `pyproject.toml` defines no `[project.optional-dependencies]`, so `--all-extras` was a no-op -- harmless now but a silent footgun if optional deps are added later without restoring the flag deliberately

Closes #44.

## Test plan

- [x] CI passes (install behavior unchanged -- all dev deps still installed via `--dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)