### PR TITLE
feat: expose __version__ on the kabsch_horn package

### DIFF
--- a/src/kabsch_horn/__init__.py
+++ b/src/kabsch_horn/__init__.py
@@ -1,6 +1,13 @@
 """Kabsch-Umeyama Algorithm Implementation across Frameworks."""
 
-__all__: list[str] = []
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("kabsch-horn-cookbook")
+except PackageNotFoundError:
+    __version__ = "unknown"
+
+__all__: list[str] = ["__version__"]
 
 # Attempt to load backends, fallback silently if not present
 try:


### PR DESCRIPTION
## Summary

- Adds `__version__` to `kabsch_horn` using `importlib.metadata.version` (stdlib since Python 3.8, no new dependency)
- Falls back to `"unknown"` via `PackageNotFoundError` for running directly from source without an install
- Adds `__version__` to `__all__`

Closes #47.

## Test plan

- [x] `import kabsch_horn; kabsch_horn.__version__` returns `"0.1.0"` on editable install
- [x] `ruff check` passes
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)