### PR TITLE
ci: document MLX platform-marker behaviour in test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
+        # MLX has sys_platform == 'darwin' in pyproject.toml, so it is
+        # skipped automatically on Linux -- no extra flag needed.
         run: uv sync --dev
 
       - name: Lint with Ruff
@@ -63,6 +65,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
+        # MLX has sys_platform == 'darwin' in pyproject.toml, so it is
+        # installed here and MLX tests run on this runner.
         run: uv sync --dev
 
       - name: Test with pytest


### PR DESCRIPTION
## Summary

All sub-tasks for #3 were already addressed by prior work; this PR closes the issue by making the intent explicit.

| Sub-task | Status |
|---|---|
| Add `macos-latest` runner for MLX tests | Done -- #60 |
| Conditional install so Linux runners skip MLX | Done -- `mlx>=0.31.0; sys_platform == 'darwin'` in `pyproject.toml` means `uv sync --dev` skips MLX on Linux automatically |
| Confirm MLX tests execute and pass on macOS | Done -- macOS CI is green |
| Document the matrix split in `CONTRIBUTING.md` | Done -- #60 |

Adds two inline comments to `test.yml` to make the Linux-skip and macOS-install behaviour visible to future contributors without requiring them to cross-reference `pyproject.toml`.

Closes #3.

## Test plan

- [x] CI passes on Linux (MLX absent, tests skip gracefully)
- [x] CI passes on macOS (MLX present, MLX tests run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)