### PR TITLE
fix(testing): remove inline imports and replace class-name dispatch in test_error_handling.py

### DIFF
--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -36,6 +36,11 @@ class FrameworkAdapter(Generic[T]):
         """Indicates whether this adapter supports N-D inputs."""
         return True
 
+    @property
+    def supports_nan_input(self) -> bool:
+        """Returns True if the framework propagates NaN through SVD without crashing."""
+        return True
+
     def convert_in(self, arr: np.ndarray) -> T:
         raise NotImplementedError
 
@@ -399,6 +404,11 @@ try:
         def supports_dim(self, dim: int) -> bool:
             # MLX implementation hardcodes 3x3 determinant correction
             return dim == 3
+
+        @property
+        def supports_nan_input(self) -> bool:
+            # MLX linalg.svd fatally aborts the process on NaN inputs
+            return False
 
         def convert_in(self, arr: np.ndarray) -> mx.array:
             self._set_device()

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 import pytest
 from adapters import FrameworkAdapter, frameworks
@@ -75,7 +77,7 @@ class TestErrorHandling:
         that raises on NaN input would be a real test failure here.
         MLX is excluded because its linalg.svd fatally aborts the process on NaN.
         """
-        if adapter.__class__.__name__ == "MLXAdapter":
+        if not adapter.supports_nan_input:
             pytest.skip(
                 "MLX linalg.svd currently throws a fatal hardware Abort on NaNs "
                 "which aborts pytest."
@@ -83,11 +85,9 @@ class TestErrorHandling:
 
         dim = 3
 
-        import numpy as np
-
-        np.random.seed(42)
-        P_np = np.random.rand(5, dim).astype(np.float64)
-        Q_np = np.random.rand(5, dim).astype(np.float64)
+        rng = np.random.default_rng(42)
+        P_np = rng.random((5, dim))
+        Q_np = rng.random((5, dim))
 
         # Inject NaN
         P_np[0, 0] = np.nan
@@ -101,8 +101,6 @@ class TestErrorHandling:
 
         for tensor in res:
             if isinstance(tensor, float):
-                import math
-
                 assert math.isnan(tensor) or adapter.is_nan(tensor), (
                     "Expected NaN to propagate"
                 )


### PR DESCRIPTION
## Summary

- Move `import math` to module level and remove duplicate `import numpy as np` from inside `test_propagates_nans_gracefully` (closes #43)
- Add `FrameworkAdapter.supports_nan_input` capability flag (defaults `True`; `MLXAdapter` overrides to `False`) and replace the `adapter.__class__.__name__ == "MLXAdapter"` string check with it (closes #41)
- Replace legacy global `np.random.seed(42)` + `np.random.rand(...)` with `np.random.default_rng(42).random(...)` to avoid mutating global RNG state (part of #41)

## Test plan

- [x] `uv run pytest tests/test_error_handling.py` -- 88 passed, 8 skipped (MLX NaN tests correctly skipped via capability flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)