### PR TITLE
fix(testing): parametrize reference validation tests over multiple seeds

### DIFF
--- a/tests/test_reference_validation.py
+++ b/tests/test_reference_validation.py
@@ -69,7 +69,7 @@ class TestReferenceValidation:
     def test_horn_matches_scipy(
         self, adapter: FrameworkAdapter, seed: int
     ) -> None:
-        """Our horn rotation matches scipy Rotation.align_vectors across multiple seeds."""
+        """Our horn rotation matches scipy Rotation.align_vectors across seeds."""
         rng = np.random.default_rng(seed)
         P_np = rng.random((20, 3))
         Q_np = rng.random((20, 3))
@@ -85,7 +85,7 @@ class TestReferenceValidation:
 
     @pytest.mark.parametrize("seed", _SEEDS)
     def test_umeyama_rotation_matches_rmsd_reference(self, seed: int) -> None:
-        """Umeyama rotation component matches rmsd kabsch rotation across multiple seeds."""
+        """Umeyama rotation component matches rmsd kabsch rotation across seeds."""
         rng = np.random.default_rng(seed)
         P_np = rng.random((20, 3))
         Q_np = rng.random((20, 3))

--- a/tests/test_reference_validation.py
+++ b/tests/test_reference_validation.py
@@ -66,9 +66,7 @@ class TestReferenceValidation:
 
     @pytest.mark.parametrize("seed", _SEEDS)
     @pytest.mark.parametrize("adapter", frameworks)
-    def test_horn_matches_scipy(
-        self, adapter: FrameworkAdapter, seed: int
-    ) -> None:
+    def test_horn_matches_scipy(self, adapter: FrameworkAdapter, seed: int) -> None:
         """Our horn rotation matches scipy Rotation.align_vectors across seeds."""
         rng = np.random.default_rng(seed)
         P_np = rng.random((20, 3))

--- a/tests/test_reference_validation.py
+++ b/tests/test_reference_validation.py
@@ -41,11 +41,17 @@ def _reference_horn_3d(P: np.ndarray, Q: np.ndarray) -> np.ndarray:
     return result[0].as_matrix()
 
 
+_SEEDS = [42, 123, 7, 99, 314]
+
+
 class TestReferenceValidation:
+    @pytest.mark.parametrize("seed", _SEEDS)
     @pytest.mark.parametrize("adapter", frameworks)
-    def test_kabsch_matches_rmsd_package(self, adapter: FrameworkAdapter) -> None:
-        """Our kabsch rotation matches the rmsd package (seed=42, 3D)."""
-        rng = np.random.default_rng(42)
+    def test_kabsch_matches_rmsd_package(
+        self, adapter: FrameworkAdapter, seed: int
+    ) -> None:
+        """Our kabsch rotation matches the rmsd package across multiple seeds."""
+        rng = np.random.default_rng(seed)
         P_np = rng.random((20, 3))
         Q_np = rng.random((20, 3))
 
@@ -58,10 +64,13 @@ class TestReferenceValidation:
 
         np.testing.assert_allclose(R_ours, R_ref, atol=adapter.atol * 10)
 
+    @pytest.mark.parametrize("seed", _SEEDS)
     @pytest.mark.parametrize("adapter", frameworks)
-    def test_horn_matches_scipy(self, adapter: FrameworkAdapter) -> None:
-        """Our horn rotation matches scipy Rotation.align_vectors (seed=42, 3D)."""
-        rng = np.random.default_rng(42)
+    def test_horn_matches_scipy(
+        self, adapter: FrameworkAdapter, seed: int
+    ) -> None:
+        """Our horn rotation matches scipy Rotation.align_vectors across multiple seeds."""
+        rng = np.random.default_rng(seed)
         P_np = rng.random((20, 3))
         Q_np = rng.random((20, 3))
 
@@ -74,9 +83,10 @@ class TestReferenceValidation:
 
         np.testing.assert_allclose(R_ours, R_ref, atol=adapter.atol * 10)
 
-    def test_umeyama_rotation_matches_rmsd_reference(self) -> None:
-        """Umeyama rotation component matches rmsd kabsch rotation (numpy, seed=123)."""
-        rng = np.random.default_rng(123)
+    @pytest.mark.parametrize("seed", _SEEDS)
+    def test_umeyama_rotation_matches_rmsd_reference(self, seed: int) -> None:
+        """Umeyama rotation component matches rmsd kabsch rotation across multiple seeds."""
+        rng = np.random.default_rng(seed)
         P_np = rng.random((20, 3))
         Q_np = rng.random((20, 3))
 
@@ -85,9 +95,10 @@ class TestReferenceValidation:
 
         np.testing.assert_allclose(R_ours, R_ref, atol=1e-5)
 
-    def test_rmsd_value_matches_rmsd_package(self) -> None:
-        """Our kabsch RMSD scalar matches rmsd.kabsch_rmsd (numpy, seed=42)."""
-        rng = np.random.default_rng(42)
+    @pytest.mark.parametrize("seed", _SEEDS)
+    def test_rmsd_value_matches_rmsd_package(self, seed: int) -> None:
+        """Our kabsch RMSD scalar matches rmsd.kabsch_rmsd across multiple seeds."""
+        rng = np.random.default_rng(seed)
         P_np = rng.random((20, 3))
         Q_np = rng.random((20, 3))
 


### PR DESCRIPTION
## Summary

Addresses #19.

**Part 2 (reference validation):** Add `@pytest.mark.parametrize("seed", [42, 123, 7, 99, 314])` to all four tests in `test_reference_validation.py`. Each test previously validated against the `rmsd`/`scipy` reference on a single fixed point cloud, so a convention mismatch or sign-flip that only appeared on certain inputs would go undetected. Test count grows from 4 to 170.

**Part 1 (dim-filtering inconsistency):** Already resolved by prior work -- the `return` guards were replaced with `assume()` in #81, and the `conftest.py` hook correctly handles fixture-based `dim` parametrization for non-Hypothesis tests.

## Test plan

- [x] `uv run pytest tests/test_reference_validation.py` -- 170 passed (was 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)