### PR TITLE
fix(testing): extend error handling coverage for horn shape mismatch and dim mismatch

### DIFF
--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -181,7 +181,7 @@ try:
         def mismatch_exception_type(
             self,
         ) -> type[Exception] | tuple[type[Exception], ...]:
-            return (AssertionError, ValueError)
+            return (AssertionError, ValueError, RuntimeError)
 
 except ImportError:
     _TORCH_AVAILABLE = False

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -6,7 +6,7 @@ from adapters import FrameworkAdapter, frameworks
 
 
 class TestErrorHandling:
-    @pytest.mark.parametrize("algo", ["kabsch", "umeyama"])
+    @pytest.mark.parametrize("algo", ["kabsch", "umeyama", "horn", "horn_with_scale"])
     @pytest.mark.parametrize("adapter", frameworks)
     def test_raises_error_when_point_counts_differ(
         self,
@@ -14,18 +14,39 @@ class TestErrorHandling:
         algo: str,
     ) -> None:
         """
-        Verifies that algorithms explicitly raise or propagate an error when
-        P and Q have mismatched point counts.
+        Verifies that all algorithms raise or propagate an error when
+        P and Q have mismatched point counts (N).
         """
-        dim = 3
-
-        # 5 points vs 4 points
-        P_np = np.random.rand(5, dim).astype(np.float64)
-        Q_np = np.random.rand(4, dim).astype(np.float64)
+        rng = np.random.default_rng(0)
+        # 5 points vs 4 points, 3D (horn requires 3D)
+        P_np = rng.random((5, 3))
+        Q_np = rng.random((4, 3))
 
         P = adapter.convert_in(P_np)
         Q = adapter.convert_in(Q_np)
-        func = adapter.kabsch_umeyama if algo == "umeyama" else adapter.kabsch
+        func = adapter.get_transform_func(algo)
+
+        with pytest.raises(adapter.mismatch_exception_type):
+            func(P, Q)
+
+    @pytest.mark.parametrize("algo", ["kabsch", "umeyama"])
+    @pytest.mark.parametrize("adapter", frameworks)
+    def test_raises_error_when_dims_differ(
+        self,
+        adapter: FrameworkAdapter,
+        algo: str,
+    ) -> None:
+        """
+        Verifies that kabsch/umeyama raise or propagate an error when
+        P and Q have mismatched dimensionality (D).
+        """
+        rng = np.random.default_rng(0)
+        P_np = rng.random((5, 3))
+        Q_np = rng.random((5, 4))  # same N, different D
+
+        P = adapter.convert_in(P_np)
+        Q = adapter.convert_in(Q_np)
+        func = adapter.get_transform_func(algo)
 
         with pytest.raises(adapter.mismatch_exception_type):
             func(P, Q)


### PR DESCRIPTION
## Summary

Closes #16. Covers the two remaining gaps (Part 1 -- bare `Exception` catch -- was already removed in #73).

**Gap 2 -- Horn not tested for N mismatch:**
- Extend `test_raises_error_when_point_counts_differ` algo list from `["kabsch", "umeyama"]` to `["kabsch", "umeyama", "horn", "horn_with_scale"]`
- Switch dispatch to `adapter.get_transform_func(algo)` and use a seeded `default_rng`
- Add `RuntimeError` to `PyTorchAdapter.mismatch_exception_type` -- PyTorch horn raises `RuntimeError` (from an invalid `reshape`) rather than `ValueError`/`AssertionError` on N mismatch

**Gap 3 -- D mismatch not tested:**
- Add `test_raises_error_when_dims_differ`: passes `P=(5, 3)` and `Q=(5, 4)` (same N, different D) to kabsch/umeyama and asserts `mismatch_exception_type` is raised

## Test plan

- [x] `uv run pytest tests/test_error_handling.py` -- 152 passed, 8 skipped (MLX NaN tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)