### PR TITLE
fix(ci): drop push trigger on dev to eliminate duplicate runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main", "dev" ]
 


### PR DESCRIPTION
## Summary

- Removes `dev` from the `push:` trigger in `test.yml`
- `pull_request` targeting `dev` already covers pre-merge validation on feature branches
- Keeping `push: dev` caused CI to fire twice on every merge to `dev` -- once for the push event and once for the PR
- `push: main` is retained for post-merge validation after release-please merges

## Test plan

- [ ] Open a PR targeting `dev` -- CI runs once via `pull_request`
- [ ] Merge the PR -- CI runs once via `push: main` only when it eventually lands on `main`; no duplicate run on `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)