### PR TITLE
fix(tests): restructure nearly_coplanar_hypothesis to _inner() pattern (closes #94, #95, #96)

### DIFF
--- a/tests/test_differentiability_traps.py
+++ b/tests/test_differentiability_traps.py
@@ -358,20 +358,15 @@ class TestDifferentiabilityTraps:
     @pytest.mark.parametrize("adapter", frameworks)
     @pytest.mark.parametrize("wrt", ["P", "Q"])
     @pytest.mark.parametrize("algo", ["kabsch", "umeyama"])
-    @settings(
-        max_examples=30,
-        suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much],
-        deadline=None,
-    )
-    @given(nearly_coplanar_nd())
     def test_gradients_stable_nearly_coplanar_hypothesis(
         self,
         adapter: FrameworkAdapter,
         wrt: str,
         algo: str,
-        P_np: np.ndarray,
     ) -> None:
         """Gradients remain finite for near-coplanar point clouds (Hypothesis)."""
+        # Skip before Hypothesis generates any examples -- condition is purely
+        # parametric (algo + precision), never data-dependent.
         if algo == "umeyama" and getattr(adapter, "precision", "float64") in (
             "float16",
             "bfloat16",
@@ -379,14 +374,24 @@ class TestDifferentiabilityTraps:
             pytest.skip(
                 "Umeyama variance division overflows float16 on near-coplanar inputs."
             )
-        # dim is drawn data -- use assume() to filter, not pytest.skip().
-        assume(adapter.supports_dim(P_np.shape[-1]))
-        Q_np = P_np.copy()
-        P = adapter.convert_in(P_np.astype(np.float64))
-        Q = adapter.convert_in(Q_np.astype(np.float64))
-        func = adapter.get_transform_func(algo)
-        grad = adapter.get_grad(P, Q, func, wrt=wrt)
-        assert np.all(np.isfinite(grad))
+
+        @settings(
+            max_examples=30,
+            suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much],
+            deadline=None,
+        )
+        @given(nearly_coplanar_nd())
+        def _inner(P_np: np.ndarray) -> None:
+            # dim is drawn data -- use assume() to filter, not pytest.skip().
+            assume(adapter.supports_dim(P_np.shape[-1]))
+            Q_np = P_np.copy()
+            P = adapter.convert_in(P_np.astype(np.float64))
+            Q = adapter.convert_in(Q_np.astype(np.float64))
+            func = adapter.get_transform_func(algo)
+            grad = adapter.get_grad(P, Q, func, wrt=wrt)
+            assert np.all(np.isfinite(grad))
+
+        _inner()
 
     @pytest.mark.parametrize("adapter", frameworks)
     @pytest.mark.parametrize("wrt", ["P", "Q"])


### PR DESCRIPTION
## Summary

- **#95 (code fix)**: `test_gradients_stable_nearly_coplanar_hypothesis` was the only test in the file using `@given` directly on the method, causing `pytest.skip()` to fire inside Hypothesis control flow -- an anti-pattern. Restructured to the `_inner()` pattern used by every other test with a parametric skip (identical to `test_gradients_stable_nearly_collinear_hypothesis`). Behaviour is unchanged; only decorator placement moves.
- **#94 (already fixed)**: `test_rmsd_invariant_to_rigid_transform` was fixed in PR #97, which replaced the trivially-satisfied `aligned_pair_nd()` strategy with `_paired_clouds_nd_composite()` and added `assume(sv_H[-1] > 1e-3)`. No code change needed here.
- **#96 (already fixed)**: Both `test_gradients_match_finite_differences_hypothesis` tests already skip for `float16`, `bfloat16`, and `float32` as of PR #97. No code change needed here.

## Test plan

- [x] `uv run pytest tests/test_differentiability_traps.py -k "nearly_coplanar_hypothesis" -v --tb=short` -- 48 passed, 16 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` -- all checks passed

Closes #94
Closes #95
Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)