### PR TITLE
fix(tests): guard nearly_coplanar_nd against dim < 3

### DIFF
--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -98,9 +98,14 @@ def nearly_collinear_3d(draw: st.DrawFn) -> np.ndarray:
 
 @st.composite
 def nearly_coplanar_nd(draw: st.DrawFn, dim: int | None = None) -> np.ndarray:
-    """N-D point cloud lying near a (dim-1) hyperplane (small normal noise)."""
+    """N-D point cloud lying near a (dim-1) hyperplane (small normal noise).
+
+    dim must be >= 3. In 2D the whole plane is the space, so "nearly coplanar"
+    is undefined; zeroing the last coordinate would produce a collinear cloud.
+    """
     if dim is None:
-        dim = draw(st.integers(3, 6))  # coplanar requires dim >= 3
+        dim = draw(st.integers(3, 6))
+    assume(dim >= 3)
     n = draw(st.integers(dim + 2, dim * 4 + 4))
     P = draw(arrays(np.float64, (n, dim), elements=st.floats(-10, 10, **_BOUNDED)))
     noise_scale = draw(st.floats(1e-4, 1e-2))


### PR DESCRIPTION
## Summary

- Add `assume(dim >= 3)` to `nearly_coplanar_nd` in `tests/strategies.py`. When a caller passes `dim=2`, the strategy zeroed the last coordinate and produced a collinear cloud -- semantically wrong for a "nearly coplanar" fixture. The `assume()` causes Hypothesis to filter and reject such examples rather than silently generating invalid data.
- Issue #92 (near-collinear gradient tests only exercise P==Q) is already resolved -- `test_gradients_stable_nearly_collinear_different_clouds` draws P and Q independently. No code change needed.

## Test plan

- [x] `uv run pytest tests/ -k "coplanar or collinear" -v` -- 1392 passed, 0 failures
- [x] `uv run pytest tests/` -- 6763 passed, 408 skipped, 4 xfailed, 0 failures
- [x] `uv run ruff check . && uv run ruff format --check .` -- clean

Closes #93
Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)