### PR TITLE
docs: document cross-covariance conditioning requirement for rotation stability

### DIFF
--- a/src/kabsch_horn/jax/kabsch_svd_nd.py
+++ b/src/kabsch_horn/jax/kabsch_svd_nd.py
@@ -99,6 +99,13 @@ def kabsch(
     Returns:
         (R, t, rmsd): Rotation [..., D, D], translation [..., D], and RMSD [...].
         float16/bfloat16 inputs are upcast to float32 internally and downcast on output.
+
+    Note:
+        R is only stable under global translation when the cross-covariance matrix
+        H = P_c.T @ Q_c is well-conditioned. When the smallest singular value of H
+        is near zero, U and V from the SVD are not unique, and a small perturbation
+        can select a different rotation. Check the singular values of H if rotation
+        stability matters for your use case.
     """
     if P.shape != Q.shape:
         raise ValueError(
@@ -184,6 +191,13 @@ def kabsch_umeyama(
         (R, t, c, rmsd): Rotation [..., D, D], translation [..., D],
         scale [...], RMSD [...].
         float16/bfloat16 inputs are upcast to float32 and downcast on output.
+
+    Note:
+        R is only stable under global translation and uniform scaling when the
+        cross-covariance matrix H = P_c.T @ Q_c is well-conditioned. When the
+        smallest singular value of H is near zero, U and V from the SVD are not
+        unique, and a small perturbation can select a different rotation. Check
+        the singular values of H if rotation stability matters for your use case.
     """
     if P.shape != Q.shape:
         raise ValueError(

--- a/src/kabsch_horn/mlx/kabsch_svd_nd.py
+++ b/src/kabsch_horn/mlx/kabsch_svd_nd.py
@@ -83,6 +83,13 @@ def kabsch(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
 
     Raises:
         ValueError: If inputs are not 3-dimensional (D != 3).
+
+    Note:
+        R is only stable under global translation when the cross-covariance matrix
+        H = P_c.T @ Q_c is well-conditioned. When the smallest singular value of H
+        is near zero, U and V from the SVD are not unique, and a small perturbation
+        can select a different rotation. Check the singular values of H if rotation
+        stability matters for your use case.
     """
     if P.shape != Q.shape:
         raise ValueError(
@@ -188,6 +195,13 @@ def kabsch_umeyama(
 
     Raises:
         ValueError: If inputs are not 3-dimensional (D != 3).
+
+    Note:
+        R is only stable under global translation and uniform scaling when the
+        cross-covariance matrix H = P_c.T @ Q_c is well-conditioned. When the
+        smallest singular value of H is near zero, U and V from the SVD are not
+        unique, and a small perturbation can select a different rotation. Check
+        the singular values of H if rotation stability matters for your use case.
     """
     if P.shape != Q.shape:
         raise ValueError(

--- a/src/kabsch_horn/numpy/kabsch_svd_nd.py
+++ b/src/kabsch_horn/numpy/kabsch_svd_nd.py
@@ -11,6 +11,13 @@ def kabsch(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.nda
 
     Returns:
         (R, t, rmsd): Rotation [..., D, D], translation [..., D], RMSD [...].
+
+    Note:
+        R is only stable under global translation when the cross-covariance matrix
+        H = P_c.T @ Q_c is well-conditioned. When the smallest singular value of H
+        is near zero, U and V from the SVD are not unique, and a small perturbation
+        can select a different rotation. Check the singular values of H if rotation
+        stability matters for your use case.
     """
     if P.shape != Q.shape:
         raise ValueError(
@@ -93,6 +100,13 @@ def kabsch_umeyama(
     Returns:
         (R, t, c, rmsd): Rotation [..., D, D], translation [..., D], scale [...],
         RMSD [...].
+
+    Note:
+        R is only stable under global translation and uniform scaling when the
+        cross-covariance matrix H = P_c.T @ Q_c is well-conditioned. When the
+        smallest singular value of H is near zero, U and V from the SVD are not
+        unique, and a small perturbation can select a different rotation. Check
+        the singular values of H if rotation stability matters for your use case.
     """
     if P.shape != Q.shape:
         raise ValueError(

--- a/src/kabsch_horn/pytorch/kabsch_svd_nd.py
+++ b/src/kabsch_horn/pytorch/kabsch_svd_nd.py
@@ -123,7 +123,20 @@ def kabsch(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Computes the optimal rotation and translation to align P to Q using Safe SVD.
-    Returns (R, t, rmsd).
+
+    Args:
+        P: Source points, shape [..., N, D].
+        Q: Target points, shape [..., N, D].
+
+    Returns:
+        (R, t, rmsd): Rotation [..., D, D], translation [..., D], RMSD [...].
+
+    Note:
+        R is only stable under global translation when the cross-covariance matrix
+        H = P_c.T @ Q_c is well-conditioned. When the smallest singular value of H
+        is near zero, U and V from the SVD are not unique, and a small perturbation
+        can select a different rotation. Check the singular values of H if rotation
+        stability matters for your use case.
     """
     if P.shape != Q.shape:
         raise ValueError(
@@ -215,7 +228,21 @@ def kabsch_umeyama(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Computes optimal rotation, translation, and scale (Q ~ c * R @ P + t).
-    Returns (R, t, c, rmsd).
+
+    Args:
+        P: Source points, shape [..., N, D].
+        Q: Target points, shape [..., N, D].
+
+    Returns:
+        (R, t, c, rmsd): Rotation [..., D, D], translation [..., D], scale [...],
+        RMSD [...].
+
+    Note:
+        R is only stable under global translation and uniform scaling when the
+        cross-covariance matrix H = P_c.T @ Q_c is well-conditioned. When the
+        smallest singular value of H is near zero, U and V from the SVD are not
+        unique, and a small perturbation can select a different rotation. Check
+        the singular values of H if rotation stability matters for your use case.
     """
     if P.shape != Q.shape:
         raise ValueError(

--- a/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
+++ b/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
@@ -69,7 +69,21 @@ def safe_svd(A: tf.Tensor) -> tuple[tf.Tensor, ...]:
 
 def kabsch(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
     """
-    Computes the optimal rotation and translation to align P and Q.
+    Computes the optimal rotation and translation to align P to Q.
+
+    Args:
+        P: Source points, shape [..., N, D].
+        Q: Target points, shape [..., N, D].
+
+    Returns:
+        (R, t, rmsd): Rotation [..., D, D], translation [..., D], RMSD [...].
+
+    Note:
+        R is only stable under global translation when the cross-covariance matrix
+        H = P_c.T @ Q_c is well-conditioned. When the smallest singular value of H
+        is near zero, U and V from the SVD are not unique, and a small perturbation
+        can select a different rotation. Check the singular values of H if rotation
+        stability matters for your use case.
     """
     if P.shape != Q.shape:
         raise ValueError(
@@ -145,7 +159,22 @@ def kabsch_umeyama(
     P: tf.Tensor, Q: tf.Tensor
 ) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor, tf.Tensor]:
     """
-    Computes the optimal rotation, translation, and scale.
+    Computes the optimal rotation, translation, and scale (Q ~ c * R @ P + t).
+
+    Args:
+        P: Source points, shape [..., N, D].
+        Q: Target points, shape [..., N, D].
+
+    Returns:
+        (R, t, c, rmsd): Rotation [..., D, D], translation [..., D], scale [...],
+        RMSD [...].
+
+    Note:
+        R is only stable under global translation and uniform scaling when the
+        cross-covariance matrix H = P_c.T @ Q_c is well-conditioned. When the
+        smallest singular value of H is near zero, U and V from the SVD are not
+        unique, and a small perturbation can select a different rotation. Check
+        the singular values of H if rotation stability matters for your use case.
     """
     if P.shape != Q.shape:
         raise ValueError(


### PR DESCRIPTION
## Summary

- Adds a `Note:` section to `kabsch` and `kabsch_umeyama` docstrings across all five frameworks (NumPy, PyTorch, JAX, TensorFlow, MLX)
- Explains that `R` is only stable under global translation (and uniform scaling for Umeyama) when `H = P_c.T @ Q_c` is well-conditioned
- Explains that near-zero smallest singular values make `U` and `V` non-unique, allowing small perturbations to select a different rotation
- Also fills in missing `Args`/`Returns` sections in PyTorch and TensorFlow docstrings that were bare one-liners

Closes #90.

## Test plan

- [ ] No behaviour changes -- docstring-only diff
- [ ] `uv run pytest tests/` passes
- [ ] `uv run ruff check .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)