### PR TITLE
fix(jax): replace vmap_diag conditional with eye-broadcast in SVD backward

### DIFF
--- a/src/kabsch_horn/jax/kabsch_svd_nd.py
+++ b/src/kabsch_horn/jax/kabsch_svd_nd.py
@@ -71,9 +71,9 @@ def _bwd(res, g):
     K = F * (Vht_dVh - mH(Vht_dVh))
 
     # 5. Build term
-    vmap_diag = jax.vmap(jnp.diag) if S.ndim > 1 else jnp.diag
-    S_diag = vmap_diag(grad_S)
-    S_mat = vmap_diag(S)
+    eye = jnp.eye(S.shape[-1], dtype=S.dtype)
+    S_diag = grad_S[..., jnp.newaxis] * eye
+    S_mat = S[..., jnp.newaxis] * eye
 
     term = S_diag - jnp.matmul(J, S_mat) - jnp.matmul(S_mat, K)
 


### PR DESCRIPTION
## Summary

- The `_bwd` VJP in `jax/kabsch_svd_nd.py` used a Python-level `if S.ndim > 1` conditional to choose between `jnp.diag` and `jax.vmap(jnp.diag)`. This is evaluated at JAX trace time, producing structurally different graphs for batched vs. unbatched inputs and forcing retracing when switching between them.
- Replaced with `v[..., jnp.newaxis] * jnp.eye(n)`, which handles both cases uniformly as a single broadcast op with no Python conditional.

Closes #31

## Test plan

- [x] `uv run pytest tests/ -q` -- 6782 passed, 408 skipped, 4 xfailed, 0 failed
- [x] JAX gradient tests (`test_gradient_verification.py`, `test_differentiability_traps.py`) all pass
- [x] Cross-framework forward equivalence unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)