### PR TITLE
fix(autograd): gradient correctness, NaN shape hardening, and sign-symmetric safe denominators

### DIFF
--- a/src/kabsch_horn/jax/horn_quat_3d.py
+++ b/src/kabsch_horn/jax/horn_quat_3d.py
@@ -37,7 +37,7 @@ def _eigh_bwd(res: tuple, g: tuple) -> tuple:
     D = L[..., jnp.newaxis, :] - L[..., jnp.newaxis]
 
     mask = jnp.abs(D) < eps
-    safe_D = jnp.where(mask, eps * jnp.sign(D + eps), D)
+    safe_D = jnp.where(mask, jnp.where(D >= 0, eps, -eps), D)
     diag_mask = jnp.eye(D.shape[-1], dtype=bool)
     safe_D = jnp.where(diag_mask, 1.0, safe_D)
     F = jnp.where(diag_mask, 0.0, 1.0 / safe_D)

--- a/src/kabsch_horn/jax/kabsch_svd_nd.py
+++ b/src/kabsch_horn/jax/kabsch_svd_nd.py
@@ -61,7 +61,7 @@ def _bwd(res, g):
     D = S_sq[..., jnp.newaxis] - S_sq[..., jnp.newaxis, :]  # BxDxD
 
     # 3. Safe F
-    safe_D = jnp.where(jnp.abs(D) < eps, eps * jnp.sign(D + eps), D)
+    safe_D = jnp.where(jnp.abs(D) < eps, jnp.where(D >= 0, eps, -eps), D)
     diag_mask = jnp.eye(D.shape[-1], dtype=bool)
     safe_D = jnp.where(diag_mask, 1.0, safe_D)
     F = jnp.where(diag_mask, 0.0, 1.0 / safe_D)

--- a/src/kabsch_horn/mlx/horn_quat_3d.py
+++ b/src/kabsch_horn/mlx/horn_quat_3d.py
@@ -23,7 +23,7 @@ def safe_eigh_bwd(primals, cotangents, outputs):
     eye = mx.eye(D.shape[-1], dtype=D.dtype)
     eps = 1e-12
     mask = mx.abs(D) < eps
-    safe_D = mx.where(mask, eps * mx.sign(D + eps), D)
+    safe_D = mx.where(mask, mx.where(D >= 0, eps, -eps), D)
     # Set diagonal to 1.0 so 1/safe_D is defined everywhere; zero it out after
     safe_D = mx.where(eye == 1, mx.ones_like(safe_D), safe_D)
 

--- a/src/kabsch_horn/pytorch/horn_quat_3d.py
+++ b/src/kabsch_horn/pytorch/horn_quat_3d.py
@@ -27,7 +27,7 @@ class SafeEigh(torch.autograd.Function):
 
         # 2. Mask unstable divides directly
         mask = torch.abs(D) < eps
-        safe_D = torch.where(mask, eps * torch.sign(D + eps), D)
+        safe_D = torch.where(mask, torch.where(D >= 0, eps, -eps), D)
 
         # 3. Prevent diagonal inversion problems outright
         safe_D.diagonal(dim1=-2, dim2=-1).fill_(1.0)

--- a/src/kabsch_horn/pytorch/kabsch_svd_nd.py
+++ b/src/kabsch_horn/pytorch/kabsch_svd_nd.py
@@ -20,11 +20,13 @@ class SafeSVD(torch.autograd.Function):
             # NaN or degenerate input: propagate NaN without crashing.
             # torch.linalg.svd raises rather than returning NaN, so we handle
             # it explicitly to satisfy the NaN-propagation contract.
-            nan_mat = A.new_full(A.shape, float("nan"))
+            # U is [..., M, M], S is [..., min(M,N)], Vh is [..., N, N]
+            nan_u = A.new_full((*A.shape[:-1], A.shape[-2]), float("nan"))
             nan_s = A.new_full(A.shape[:-1], float("nan"))
-            ctx.save_for_backward(nan_mat, nan_s, nan_mat)
+            nan_vh = A.new_full((*A.shape[:-2], A.shape[-1], A.shape[-1]), float("nan"))
+            ctx.save_for_backward(nan_u, nan_s, nan_vh)
             ctx.eps = eps
-            return nan_mat, nan_s, nan_mat
+            return nan_u, nan_s, nan_u
         # In PyTorch 1.11+, linalg.svd returns Vh (V^T or V^H).
         # We want V for the standard Kabsch logic, so V = Vh.transpose(-2, -1)
         V = Vh.mH  # Conjugate transpose / standard transpose for real.

--- a/src/kabsch_horn/pytorch/kabsch_svd_nd.py
+++ b/src/kabsch_horn/pytorch/kabsch_svd_nd.py
@@ -26,7 +26,7 @@ class SafeSVD(torch.autograd.Function):
             nan_vh = A.new_full((*A.shape[:-2], A.shape[-1], A.shape[-1]), float("nan"))
             ctx.save_for_backward(nan_u, nan_s, nan_vh)
             ctx.eps = eps
-            return nan_u, nan_s, nan_u
+            return nan_u, nan_s, nan_vh
         # In PyTorch 1.11+, linalg.svd returns Vh (V^T or V^H).
         # We want V for the standard Kabsch logic, so V = Vh.transpose(-2, -1)
         V = Vh.mH  # Conjugate transpose / standard transpose for real.

--- a/src/kabsch_horn/pytorch/kabsch_svd_nd.py
+++ b/src/kabsch_horn/pytorch/kabsch_svd_nd.py
@@ -22,7 +22,8 @@ class SafeSVD(torch.autograd.Function):
             # it explicitly to satisfy the NaN-propagation contract.
             # U is [..., M, M], S is [..., min(M,N)], Vh is [..., N, N]
             nan_u = A.new_full((*A.shape[:-1], A.shape[-2]), float("nan"))
-            nan_s = A.new_full(A.shape[:-1], float("nan"))
+            M, N = A.shape[-2], A.shape[-1]
+            nan_s = A.new_full((*A.shape[:-2], min(M, N)), float("nan"))
             nan_vh = A.new_full((*A.shape[:-2], A.shape[-1], A.shape[-1]), float("nan"))
             ctx.save_for_backward(nan_u, nan_s, nan_vh)
             ctx.eps = eps
@@ -68,8 +69,8 @@ class SafeSVD(torch.autograd.Function):
         D_abs = torch.abs(D)
         mask = D_abs < eps
 
-        # Safe denominator replacing small elements with eps * sign
-        safe_D = torch.where(mask, eps * torch.sign(D + eps), D)
+        # Safe denominator preserving sign for sub-eps values
+        safe_D = torch.where(mask, torch.where(D >= 0, eps, -eps), D)
 
         # Protect diagonal from 1/0
         safe_D.diagonal(dim1=-2, dim2=-1).fill_(1.0)

--- a/src/kabsch_horn/tensorflow/horn_quat_3d.py
+++ b/src/kabsch_horn/tensorflow/horn_quat_3d.py
@@ -19,7 +19,7 @@ def call_safe_eigh(A):
         D = tf.expand_dims(L, -2) - tf.expand_dims(L, -1)
 
         mask = tf.abs(D) < eps
-        safe_D = tf.where(mask, eps * tf.sign(D + eps), D)
+        safe_D = tf.where(mask, tf.where(D >= 0, eps, -eps), D)
         safe_D = tf.linalg.set_diag(safe_D, tf.ones_like(tf.linalg.diag_part(safe_D)))
 
         F = 1.0 / safe_D

--- a/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
+++ b/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
@@ -34,7 +34,7 @@ def safe_svd(A: tf.Tensor) -> tuple[tf.Tensor, ...]:
         # to prevent 1/0 = inf on off-diagonal entries where S_i ≈ S_j
         eps = tf.cast(1e-12, S.dtype)
         mask = tf.abs(S_sq_diff) < eps
-        safe_D = tf.where(mask, eps * tf.sign(S_sq_diff + eps), S_sq_diff)
+        safe_D = tf.where(mask, tf.where(S_sq_diff >= 0, eps, -eps), S_sq_diff)
         safe_D = tf.linalg.set_diag(safe_D, tf.ones_like(tf.linalg.diag_part(safe_D)))
         F = 1.0 / safe_D
         # Zero out the diagonal of F

--- a/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
+++ b/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
@@ -30,13 +30,15 @@ def safe_svd(A: tf.Tensor) -> tuple[tf.Tensor, ...]:
         S_sq = tf.square(S)
         S_sq_diff = tf.expand_dims(S_sq, -2) - tf.expand_dims(S_sq, -1)
 
-        # Add epsilon to diagonal before reciprocal to avoid Division by Zero problems
-        eye = tf.eye(tf.shape(S)[-1], dtype=S.dtype)
-        S_sq_diff_safe = tf.where(tf.abs(S_sq_diff) < 1e-12, eye * 1e-12, S_sq_diff)
-
-        F = 1.0 / S_sq_diff_safe
+        # Safe denominator: replace near-zero differences with eps * sign
+        # to prevent 1/0 = inf on off-diagonal entries where S_i ≈ S_j
+        eps = tf.cast(1e-12, S.dtype)
+        mask = tf.abs(S_sq_diff) < eps
+        safe_D = tf.where(mask, eps * tf.sign(S_sq_diff + eps), S_sq_diff)
+        safe_D = tf.linalg.set_diag(safe_D, tf.ones_like(tf.linalg.diag_part(safe_D)))
+        F = 1.0 / safe_D
         # Zero out the diagonal of F
-        F = tf.linalg.set_diag(F, tf.zeros_like(S))
+        F = tf.linalg.set_diag(F, tf.zeros_like(tf.linalg.diag_part(F)))
 
         if dU is not None:
             Ut_dU = tf.matmul(Ut, dU)


### PR DESCRIPTION
## Summary

- **TF `safe_svd` backward** (#123): The `eye * 1e-12` mask was zero on off-diagonal entries where `S_i ≈ S_j`, causing `1/0 = inf`. Replaced with sign-preserving `where(D >= 0, eps, -eps)` pattern.
- **PyTorch `SafeSVD` NaN fallback** (#116): `nan_mat` (shape `A.shape`) was reused for both U and Vh in `save_for_backward`. For rectangular inputs Vh is `[..., N, N]`, not `A.shape`. Now creates properly-shaped `nan_u` and `nan_vh` tensors, and returns `nan_vh` (not `nan_u`) for V.
- **`nan_s` shape hardening**: `nan_s` now uses `min(M, N)` instead of `A.shape[:-1]`, matching the real SVD contract for non-square inputs.
- **Sign-symmetric safe denominators**: Replaced `eps * sign(D + eps)` with `where(D >= 0, eps, -eps)` across all framework backward passes (`kabsch_svd_nd` and `horn_quat_3d` in PyTorch, JAX, TensorFlow, and MLX). The old pattern biased sub-eps negative differences to `+eps` because the `+eps` nudge inside `sign()` made them positive.

Fixes #123, fixes #116.

## Test plan

- [x] `uv run ruff check . && uv run ruff format .` -- passes
- [x] `uv run pytest tests/ -v` -- full suite: 6846 passed, 440 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)