### PR TITLE
fix(pytorch,tensorflow): remove in-place mutations and tf.rank tracing bug

### DIFF
--- a/src/kabsch_horn/pytorch/horn_quat_3d.py
+++ b/src/kabsch_horn/pytorch/horn_quat_3d.py
@@ -29,10 +29,11 @@ class SafeEigh(torch.autograd.Function):
         mask = torch.abs(D) < eps
         safe_D = torch.where(mask, torch.where(D >= 0, eps, -eps), D)
 
-        # 3. Prevent diagonal inversion problems outright
-        safe_D.diagonal(dim1=-2, dim2=-1).fill_(1.0)
+        # 3. Prevent diagonal inversion problems (out-of-place for torch.compile)
+        diag_mask = torch.eye(safe_D.shape[-1], dtype=torch.bool, device=safe_D.device)
+        safe_D = torch.where(diag_mask, torch.ones_like(safe_D), safe_D)
         F = 1.0 / safe_D
-        F.diagonal(dim1=-2, dim2=-1).zero_()
+        F = torch.where(diag_mask, torch.zeros_like(F), F)
 
         # 4. Standard backprop algebra using safe denominators
         Vt_dV = torch.matmul(V.mH, grad_V)

--- a/src/kabsch_horn/pytorch/kabsch_svd_nd.py
+++ b/src/kabsch_horn/pytorch/kabsch_svd_nd.py
@@ -72,12 +72,13 @@ class SafeSVD(torch.autograd.Function):
         # Safe denominator preserving sign for sub-eps values
         safe_D = torch.where(mask, torch.where(D >= 0, eps, -eps), D)
 
-        # Protect diagonal from 1/0
-        safe_D.diagonal(dim1=-2, dim2=-1).fill_(1.0)
+        # Protect diagonal from 1/0 (out-of-place for torch.compile)
+        diag_mask = torch.eye(safe_D.shape[-1], dtype=torch.bool, device=safe_D.device)
+        safe_D = torch.where(diag_mask, torch.ones_like(safe_D), safe_D)
 
         F = 1.0 / safe_D
         # Set diagonal to exactly 0 to satisfy Hadamard condition
-        F.diagonal(dim1=-2, dim2=-1).zero_()
+        F = torch.where(diag_mask, torch.zeros_like(F), F)
 
         # 4. Compute J and K
         Ut_dU = torch.matmul(U.mH, grad_U)

--- a/src/kabsch_horn/tensorflow/horn_quat_3d.py
+++ b/src/kabsch_horn/tensorflow/horn_quat_3d.py
@@ -52,7 +52,7 @@ def horn(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
         P = tf.cast(P, tf.float32)
         Q = tf.cast(Q, tf.float32)
 
-    is_single = tf.rank(P) == 2
+    is_single = len(P.shape) == 2
     if is_single:
         P = tf.expand_dims(P, 0)
         Q = tf.expand_dims(Q, 0)
@@ -156,7 +156,7 @@ def horn_with_scale(
         P = tf.cast(P, tf.float32)
         Q = tf.cast(Q, tf.float32)
 
-    is_single = tf.rank(P) == 2
+    is_single = len(P.shape) == 2
     if is_single:
         P = tf.expand_dims(P, 0)
         Q = tf.expand_dims(Q, 0)


### PR DESCRIPTION
## Summary
- **#111**: Replace in-place `.diagonal().fill_()` / `.diagonal().zero_()` in PyTorch `SafeSVD.backward` and `SafeEigh.backward` with out-of-place `torch.where` using a boolean diagonal mask. Fixes `torch.compile` graph breaks and `RuntimeError` under `create_graph=True`.
- **#124**: Replace `tf.rank(P) == 2` with `len(P.shape) == 2` in TF `horn` and `horn_with_scale`. `tf.rank()` returns a symbolic tensor, so the Python `if` fails under `@tf.function` tracing.

Closes #111
Closes #124

## Test plan
- [x] Full test suite passes (6846 passed, 440 skipped, 4 xfailed)
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)