### PR TITLE
fix: P1 correctness bugs and review follow-ups (#128, #127, #130)

### DIFF
--- a/src/kabsch_horn/jax/horn_quat_3d.py
+++ b/src/kabsch_horn/jax/horn_quat_3d.py
@@ -141,6 +141,8 @@ def horn(
         )
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")
+    if P.shape[-2] < 2:
+        raise ValueError("At least 2 points are required for alignment")
     orig_dtype = P.dtype
     if orig_dtype in (jnp.float16, jnp.bfloat16):
         P = P.astype(jnp.float32)
@@ -214,6 +216,8 @@ def horn_with_scale(
         )
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")
+    if P.shape[-2] < 2:
+        raise ValueError("At least 2 points are required for alignment")
     orig_dtype = P.dtype
     if orig_dtype in (jnp.float16, jnp.bfloat16):
         P = P.astype(jnp.float32)

--- a/src/kabsch_horn/mlx/horn_quat_3d.py
+++ b/src/kabsch_horn/mlx/horn_quat_3d.py
@@ -71,6 +71,8 @@ def horn(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
         )
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")
+    if P.shape[-2] < 2:
+        raise ValueError("At least 2 points are required for alignment")
     orig_dtype = P.dtype
     if orig_dtype in (mx.float16, mx.bfloat16):
         P = P.astype(mx.float32)
@@ -185,6 +187,8 @@ def horn_with_scale(
         )
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")
+    if P.shape[-2] < 2:
+        raise ValueError("At least 2 points are required for alignment")
     orig_dtype = P.dtype
     if orig_dtype in (mx.float16, mx.bfloat16):
         P = P.astype(mx.float32)

--- a/src/kabsch_horn/mlx/horn_quat_3d.py
+++ b/src/kabsch_horn/mlx/horn_quat_3d.py
@@ -65,10 +65,6 @@ def horn(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
         )
     _warn_if_float64(P, Q)
-    if P.shape != Q.shape:
-        raise ValueError(
-            f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
-        )
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")
     if P.shape[-2] < 2:
@@ -181,10 +177,6 @@ def horn_with_scale(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
         )
     _warn_if_float64(P, Q)
-    if P.shape != Q.shape:
-        raise ValueError(
-            f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
-        )
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")
     if P.shape[-2] < 2:

--- a/src/kabsch_horn/numpy/horn_quat_3d.py
+++ b/src/kabsch_horn/numpy/horn_quat_3d.py
@@ -23,7 +23,7 @@ def _build_horn_matrix(H: np.ndarray) -> np.ndarray:
     )
 
     B = H.shape[0]
-    I3 = np.broadcast_to(np.eye(3), (B, 3, 3))
+    I3 = np.broadcast_to(np.eye(3, dtype=H.dtype), (B, 3, 3))
 
     top_row = np.concatenate([tr[..., np.newaxis], Delta], axis=-1)[:, np.newaxis, :]
     bottom_block = np.concatenate(
@@ -83,6 +83,11 @@ def horn(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarr
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
 
+    orig_dtype = P.dtype
+    if orig_dtype in (np.float16,):
+        P = P.astype(np.float32)
+        Q = Q.astype(np.float32)
+
     is_single = P.ndim == 2
     if is_single:
         P = P[np.newaxis, ...]
@@ -125,12 +130,16 @@ def horn(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarr
     )
 
     if is_single:
-        return R[0], t[0], rmsd[0]
-    return (
-        R.reshape(*batch_dims, D, D),
-        t.reshape(*batch_dims, D),
-        rmsd.reshape(*batch_dims),
-    )
+        R, t, rmsd = R[0], t[0], rmsd[0]
+    else:
+        R = R.reshape(*batch_dims, D, D)
+        t = t.reshape(*batch_dims, D)
+        rmsd = rmsd.reshape(*batch_dims)
+    if orig_dtype in (np.float16,):
+        R = R.astype(orig_dtype)
+        t = t.astype(orig_dtype)
+        rmsd = rmsd.astype(orig_dtype)
+    return R, t, rmsd
 
 
 def horn_with_scale(
@@ -158,6 +167,11 @@ def horn_with_scale(
         raise ValueError("Horn's method is strictly for 3D point clouds")
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
+
+    orig_dtype = P.dtype
+    if orig_dtype in (np.float16,):
+        P = P.astype(np.float32)
+        Q = Q.astype(np.float32)
 
     is_single = P.ndim == 2
     if is_single:
@@ -205,10 +219,15 @@ def horn_with_scale(
     )
 
     if is_single:
-        return R[0], t[0], c[0], rmsd[0]
-    return (
-        R.reshape(*batch_dims, D, D),
-        t.reshape(*batch_dims, D),
-        c.reshape(*batch_dims),
-        rmsd.reshape(*batch_dims),
-    )
+        R, t, c, rmsd = R[0], t[0], c[0], rmsd[0]
+    else:
+        R = R.reshape(*batch_dims, D, D)
+        t = t.reshape(*batch_dims, D)
+        c = c.reshape(*batch_dims)
+        rmsd = rmsd.reshape(*batch_dims)
+    if orig_dtype in (np.float16,):
+        R = R.astype(orig_dtype)
+        t = t.astype(orig_dtype)
+        c = c.astype(orig_dtype)
+        rmsd = rmsd.astype(orig_dtype)
+    return R, t, c, rmsd

--- a/src/kabsch_horn/numpy/kabsch_svd_nd.py
+++ b/src/kabsch_horn/numpy/kabsch_svd_nd.py
@@ -26,6 +26,11 @@ def kabsch(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.nda
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
 
+    orig_dtype = P.dtype
+    if orig_dtype in (np.float16,):
+        P = P.astype(np.float32)
+        Q = Q.astype(np.float32)
+
     # Auto-batch single elements
     is_single = P.ndim == 2
     if is_single:
@@ -84,12 +89,16 @@ def kabsch(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.nda
     )
 
     if is_single:
-        return R[0], t[0], rmsd[0]
-    return (
-        R.reshape(*batch_dims, D, D),
-        t.reshape(*batch_dims, D),
-        rmsd.reshape(*batch_dims),
-    )
+        R, t, rmsd = R[0], t[0], rmsd[0]
+    else:
+        R = R.reshape(*batch_dims, D, D)
+        t = t.reshape(*batch_dims, D)
+        rmsd = rmsd.reshape(*batch_dims)
+    if orig_dtype in (np.float16,):
+        R = R.astype(orig_dtype)
+        t = t.astype(orig_dtype)
+        rmsd = rmsd.astype(orig_dtype)
+    return R, t, rmsd
 
 
 def kabsch_umeyama(
@@ -120,6 +129,11 @@ def kabsch_umeyama(
         )
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
+
+    orig_dtype = P.dtype
+    if orig_dtype in (np.float16,):
+        P = P.astype(np.float32)
+        Q = Q.astype(np.float32)
 
     is_single = P.ndim == 2
     if is_single:
@@ -185,10 +199,15 @@ def kabsch_umeyama(
     )
 
     if is_single:
-        return R[0], t[0], c[0], rmsd[0]
-    return (
-        R.reshape(*batch_dims, D, D),
-        t.reshape(*batch_dims, D),
-        c.reshape(*batch_dims),
-        rmsd.reshape(*batch_dims),
-    )
+        R, t, c, rmsd = R[0], t[0], c[0], rmsd[0]
+    else:
+        R = R.reshape(*batch_dims, D, D)
+        t = t.reshape(*batch_dims, D)
+        c = c.reshape(*batch_dims)
+        rmsd = rmsd.reshape(*batch_dims)
+    if orig_dtype in (np.float16,):
+        R = R.astype(orig_dtype)
+        t = t.astype(orig_dtype)
+        c = c.astype(orig_dtype)
+        rmsd = rmsd.astype(orig_dtype)
+    return R, t, c, rmsd

--- a/src/kabsch_horn/pytorch/horn_quat_3d.py
+++ b/src/kabsch_horn/pytorch/horn_quat_3d.py
@@ -57,6 +57,8 @@ def horn(
         )
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")
+    if P.shape[-2] < 2:
+        raise ValueError("At least 2 points are required for alignment")
     orig_dtype = P.dtype
     if orig_dtype in (torch.float16, torch.bfloat16):
         P = P.to(torch.float32)
@@ -178,6 +180,8 @@ def horn_with_scale(
         )
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")
+    if P.shape[-2] < 2:
+        raise ValueError("At least 2 points are required for alignment")
     orig_dtype = P.dtype
     if orig_dtype in (torch.float16, torch.bfloat16):
         P = P.to(torch.float32)

--- a/src/kabsch_horn/tensorflow/horn_quat_3d.py
+++ b/src/kabsch_horn/tensorflow/horn_quat_3d.py
@@ -46,6 +46,8 @@ def horn(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
         )
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")
+    if P.shape[-2] is not None and P.shape[-2] < 2:
+        raise ValueError("At least 2 points are required for alignment")
 
     orig_dtype = P.dtype
     if orig_dtype in (tf.float16, tf.bfloat16):
@@ -150,6 +152,8 @@ def horn_with_scale(
         )
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")
+    if P.shape[-2] is not None and P.shape[-2] < 2:
+        raise ValueError("At least 2 points are required for alignment")
 
     orig_dtype = P.dtype
     if orig_dtype in (tf.float16, tf.bfloat16):

--- a/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
+++ b/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
@@ -91,7 +91,7 @@ def kabsch(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
         )
-    if P.shape[-2] < 2:
+    if P.shape[-2] is not None and P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
 
     orig_dtype = P.dtype
@@ -184,7 +184,7 @@ def kabsch_umeyama(
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
         )
-    if P.shape[-2] < 2:
+    if P.shape[-2] is not None and P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
 
     orig_dtype = P.dtype

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -129,6 +129,29 @@ class TestErrorHandling:
                 assert adapter.is_nan(tensor), "Expected NaN to propagate to output"
 
 
+class TestNumpySinglePointRejection:
+    """NumPy N=1 inputs must raise ValueError for all algorithms."""
+
+    @pytest.mark.parametrize(
+        "algo", ["kabsch", "kabsch_umeyama", "horn", "horn_with_scale"]
+    )
+    def test_numpy_single_point_raises_value_error(self, algo: str) -> None:
+        from kabsch_horn.numpy import horn, horn_with_scale, kabsch, kabsch_umeyama
+
+        P = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+        Q = np.array([[4.0, 5.0, 6.0]], dtype=np.float64)
+
+        func_map = {
+            "kabsch": kabsch,
+            "kabsch_umeyama": kabsch_umeyama,
+            "horn": horn,
+            "horn_with_scale": horn_with_scale,
+        }
+
+        with pytest.raises(ValueError, match="2 points"):
+            func_map[algo](P, Q)
+
+
 class TestNumpyFloat16Upcast:
     """NumPy float16 inputs should be upcast internally (not raise TypeError)."""
 

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -197,6 +197,20 @@ class TestNumpyFloat16Upcast:
         for arr in result:
             assert arr.dtype == np.float16, f"Expected float16 output, got {arr.dtype}"
 
+    @pytest.mark.parametrize("algo", ["kabsch", "kabsch_umeyama"])
+    def test_numpy_float16_higher_dim(self, algo: str) -> None:
+        from kabsch_horn.numpy import kabsch, kabsch_umeyama
+
+        rng = np.random.default_rng(2)
+        P = rng.random((5, 4)).astype(np.float16)
+        Q = rng.random((5, 4)).astype(np.float16)
+
+        func = kabsch if algo == "kabsch" else kabsch_umeyama
+        result = func(P, Q)
+
+        for arr in result:
+            assert arr.dtype == np.float16, f"Expected float16 output, got {arr.dtype}"
+
 
 class TestNumpyFloat32DtypePromotion:
     """NumPy functions should preserve float32 (not promote to float64)."""

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -176,6 +176,27 @@ class TestNumpyFloat16Upcast:
         for arr in result:
             assert arr.dtype == np.float16, f"Expected float16 output, got {arr.dtype}"
 
+    @pytest.mark.parametrize(
+        "algo", ["kabsch", "kabsch_umeyama", "horn", "horn_with_scale"]
+    )
+    def test_numpy_float16_batched(self, algo: str) -> None:
+        from kabsch_horn.numpy import horn, horn_with_scale, kabsch, kabsch_umeyama
+
+        rng = np.random.default_rng(1)
+        P = rng.random((2, 5, 3)).astype(np.float16)
+        Q = rng.random((2, 5, 3)).astype(np.float16)
+
+        func_map = {
+            "kabsch": kabsch,
+            "kabsch_umeyama": kabsch_umeyama,
+            "horn": horn,
+            "horn_with_scale": horn_with_scale,
+        }
+        result = func_map[algo](P, Q)
+
+        for arr in result:
+            assert arr.dtype == np.float16, f"Expected float16 output, got {arr.dtype}"
+
 
 class TestNumpyFloat32DtypePromotion:
     """NumPy functions should preserve float32 (not promote to float64)."""

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -178,18 +178,25 @@ class TestNumpyFloat16Upcast:
 
 
 class TestNumpyFloat32DtypePromotion:
-    """NumPy horn functions should preserve float32 (not promote to float64)."""
+    """NumPy functions should preserve float32 (not promote to float64)."""
 
-    @pytest.mark.parametrize("algo", ["horn", "horn_with_scale"])
-    def test_horn_float32_stays_float32(self, algo: str) -> None:
-        from kabsch_horn.numpy import horn, horn_with_scale
+    @pytest.mark.parametrize(
+        "algo", ["kabsch", "kabsch_umeyama", "horn", "horn_with_scale"]
+    )
+    def test_float32_stays_float32(self, algo: str) -> None:
+        from kabsch_horn.numpy import horn, horn_with_scale, kabsch, kabsch_umeyama
 
         rng = np.random.default_rng(0)
         P = rng.random((5, 3)).astype(np.float32)
         Q = rng.random((5, 3)).astype(np.float32)
 
-        func = horn if algo == "horn" else horn_with_scale
-        result = func(P, Q)
+        func_map = {
+            "kabsch": kabsch,
+            "kabsch_umeyama": kabsch_umeyama,
+            "horn": horn,
+            "horn_with_scale": horn_with_scale,
+        }
+        result = func_map[algo](P, Q)
 
         for arr in result:
             assert arr.dtype == np.float32, f"Expected float32 output, got {arr.dtype}"

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -127,3 +127,46 @@ class TestErrorHandling:
                 )
             else:
                 assert adapter.is_nan(tensor), "Expected NaN to propagate to output"
+
+
+class TestNumpyFloat16Upcast:
+    """NumPy float16 inputs should be upcast internally (not raise TypeError)."""
+
+    @pytest.mark.parametrize(
+        "algo", ["kabsch", "kabsch_umeyama", "horn", "horn_with_scale"]
+    )
+    def test_numpy_float16_no_type_error(self, algo: str) -> None:
+        from kabsch_horn.numpy import horn, horn_with_scale, kabsch, kabsch_umeyama
+
+        rng = np.random.default_rng(0)
+        P = rng.random((5, 3)).astype(np.float16)
+        Q = rng.random((5, 3)).astype(np.float16)
+
+        func_map = {
+            "kabsch": kabsch,
+            "kabsch_umeyama": kabsch_umeyama,
+            "horn": horn,
+            "horn_with_scale": horn_with_scale,
+        }
+        result = func_map[algo](P, Q)
+
+        for arr in result:
+            assert arr.dtype == np.float16, f"Expected float16 output, got {arr.dtype}"
+
+
+class TestNumpyFloat32DtypePromotion:
+    """NumPy horn functions should preserve float32 (not promote to float64)."""
+
+    @pytest.mark.parametrize("algo", ["horn", "horn_with_scale"])
+    def test_horn_float32_stays_float32(self, algo: str) -> None:
+        from kabsch_horn.numpy import horn, horn_with_scale
+
+        rng = np.random.default_rng(0)
+        P = rng.random((5, 3)).astype(np.float32)
+        Q = rng.random((5, 3)).astype(np.float32)
+
+        func = horn if algo == "horn" else horn_with_scale
+        result = func(P, Q)
+
+        for arr in result:
+            assert arr.dtype == np.float32, f"Expected float32 output, got {arr.dtype}"

--- a/tests/test_rmsd_wrappers.py
+++ b/tests/test_rmsd_wrappers.py
@@ -143,7 +143,7 @@ class TestKabschRmsdWrappers:
 class TestSinglePoint:
     """Edge case: N=1 (single point pair) -- rejected as underdetermined."""
 
-    @pytest.mark.parametrize("algo", ["kabsch", "umeyama"])
+    @pytest.mark.parametrize("algo", ["kabsch", "umeyama", "horn", "horn_with_scale"])
     @pytest.mark.parametrize("adapter", frameworks)
     def test_single_point_raises_value_error(
         self,
@@ -158,7 +158,13 @@ class TestSinglePoint:
 
         P = adapter.convert_in(P_np)
         Q = adapter.convert_in(Q_np)
-        func = adapter.kabsch_umeyama if algo == "umeyama" else adapter.kabsch
+        func_map = {
+            "kabsch": adapter.kabsch,
+            "umeyama": adapter.kabsch_umeyama,
+            "horn": adapter.horn,
+            "horn_with_scale": adapter.horn_with_scale,
+        }
+        func = func_map[algo]
 
         with pytest.raises(ValueError, match="2 points"):
             func(P, Q)


### PR DESCRIPTION
## Summary

- **#127**: `np.eye(3)` in `_build_horn_matrix` defaults to float64, silently upcasting float32 inputs. Fixed by passing `dtype=H.dtype`.
- **#128**: NumPy `kabsch`, `kabsch_umeyama`, `horn`, and `horn_with_scale` throw `TypeError` on float16 inputs. Added upcast-to-float32/downcast-on-output guard matching the pattern in all other frameworks.
- **#130**: Horn's `horn()` and `horn_with_scale()` missing N>=2 validation in PyTorch, JAX, TensorFlow, and MLX (NumPy already had it). Added consistent `ValueError` check.

### Review follow-ups

- **MLX**: Removed duplicate `P.shape != Q.shape` checks in `horn()` and `horn_with_scale()` (dead code)
- **TF**: Added `is not None` guard to `kabsch()` and `kabsch_umeyama()` N>=2 checks, matching the new horn guards (prevents `TypeError` under `tf.function` with dynamic shapes)
- **TF dynamic-shape validation gap**: Filed as #134 (runtime `tf.debugging.assert_*` for symbolic shapes -- out of scope for this PR)

## Test plan

- [x] NumPy N=1 rejection: all 4 algos via direct import (not in `frameworks` fixture)
- [x] NumPy float16 upcast: single `(5, 3)`, batched `(2, 5, 3)`, and N-D `(5, 4)` inputs
- [x] NumPy float32 dtype preservation: all 4 algos return float32 (not float64)
- [x] Horn/horn_with_scale N=1 rejection: extended `TestSinglePoint` across all framework adapters
- [x] Full suite: 6884 passed, 440 skipped, 4 xfailed
- [x] `ruff check` and `ruff format` clean

Closes #127, closes #128, closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)