### PR TITLE
fix: replace hardcoded eps=1e-12 with dtype-aware finfo(dtype).eps (#110)

### DIFF
--- a/src/kabsch_horn/jax/horn_quat_3d.py
+++ b/src/kabsch_horn/jax/horn_quat_3d.py
@@ -3,21 +3,21 @@ import jax.numpy as jnp
 
 
 @jax.custom_vjp
-def safe_eigh(A: jnp.ndarray, eps: float = 1e-12) -> tuple[jnp.ndarray, jnp.ndarray]:
+def safe_eigh(A: jnp.ndarray) -> tuple[jnp.ndarray, jnp.ndarray]:
     """Gradient-safe eigendecomposition for symmetric matrices. Masks near-zero
     eigenvalue differences (< eps) in the backward pass to prevent NaN gradients."""
     return jnp.linalg.eigh(A)
 
 
 def _eigh_fwd(
-    A: jnp.ndarray, eps: float
+    A: jnp.ndarray,
 ) -> tuple[tuple[jnp.ndarray, jnp.ndarray], tuple]:
     L, V = jnp.linalg.eigh(A)
-    return (L, V), (L, V, eps)
+    return (L, V), (L, V)
 
 
 def _eigh_bwd(res: tuple, g: tuple) -> tuple:
-    L, V, eps = res
+    L, V = res
     grad_L, grad_V = g
 
     grad_L = (
@@ -36,6 +36,7 @@ def _eigh_bwd(res: tuple, g: tuple) -> tuple:
 
     D = L[..., jnp.newaxis, :] - L[..., jnp.newaxis]
 
+    eps = jnp.finfo(L.dtype).eps
     mask = jnp.abs(D) < eps
     safe_D = jnp.where(mask, jnp.where(D >= 0, eps, -eps), D)
     diag_mask = jnp.eye(D.shape[-1], dtype=bool)
@@ -49,7 +50,7 @@ def _eigh_bwd(res: tuple, g: tuple) -> tuple:
     term = L_diag + F * (Vt_dV - mH(Vt_dV)) / 2
     grad_A = jnp.matmul(V, jnp.matmul(term, mH(V)))
 
-    return (grad_A, None)
+    return (grad_A,)
 
 
 safe_eigh.defvjp(_eigh_fwd, _eigh_bwd)
@@ -166,10 +167,11 @@ def horn(
     )
 
     aligned = jnp.matmul(p, jnp.swapaxes(R, 1, 2))
+    _eps = jnp.finfo(P.dtype).eps
     rmsd = jnp.sqrt(
         jnp.clip(
             jnp.sum(jnp.square(aligned - q), axis=(1, 2)) / N_pts,
-            min=1e-12,
+            min=_eps,
             max=None,
         )
     )
@@ -238,8 +240,9 @@ def horn_with_scale(
 
     # H is unscaled (p.T @ q); var_P * N_pts = sum(sq(p)), so c = tr(R^T H) / sum(sq(p))
     var_P = jnp.sum(jnp.square(p), axis=(1, 2)) / N_pts
+    _eps = jnp.finfo(P.dtype).eps
     c = jnp.sum(R * jnp.swapaxes(H, 1, 2), axis=(1, 2)) / (
-        jnp.clip(var_P, min=1e-12) * N_pts
+        jnp.clip(var_P, min=_eps) * N_pts
     )
 
     t = jnp.squeeze(centroid_Q, axis=1) - c[:, jnp.newaxis] * jnp.squeeze(
@@ -252,7 +255,7 @@ def horn_with_scale(
     )
     diff = aligned_P - Q
     rmsd = jnp.sqrt(
-        jnp.clip(jnp.sum(jnp.square(diff), axis=(1, 2)) / N_pts, min=1e-12, max=None)
+        jnp.clip(jnp.sum(jnp.square(diff), axis=(1, 2)) / N_pts, min=_eps, max=None)
     )
 
     if is_single:

--- a/src/kabsch_horn/jax/kabsch_svd_nd.py
+++ b/src/kabsch_horn/jax/kabsch_svd_nd.py
@@ -4,7 +4,7 @@ import jax.numpy as jnp
 
 @jax.custom_vjp
 def safe_svd(
-    A: jnp.ndarray, eps: float = 1e-12
+    A: jnp.ndarray,
 ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
     """Gradient-safe SVD. Masks near-zero singular value differences (< eps) in the
     backward pass to prevent NaN gradients for symmetric or degenerate inputs.
@@ -19,17 +19,17 @@ def safe_svd(
 
 
 def _fwd(
-    A: jnp.ndarray, eps: float
+    A: jnp.ndarray,
 ) -> tuple[tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple]:
     U, S, Vh = jnp.linalg.svd(A)
     # return primal outputs and residuals for backward pass
     V = jnp.swapaxes(jnp.conj(Vh), -1, -2)
-    return (U, S, V), (U, S, Vh, eps)
+    return (U, S, V), (U, S, Vh)
 
 
 def _bwd(res, g):
     # Retrieve
-    U, S, Vh, eps = res
+    U, S, Vh = res
     grad_U, grad_S, grad_V = g
 
     # Check if None or SymbolicZero
@@ -61,6 +61,7 @@ def _bwd(res, g):
     D = S_sq[..., jnp.newaxis] - S_sq[..., jnp.newaxis, :]  # BxDxD
 
     # 3. Safe F
+    eps = jnp.finfo(S.dtype).eps
     safe_D = jnp.where(jnp.abs(D) < eps, jnp.where(D >= 0, eps, -eps), D)
     diag_mask = jnp.eye(D.shape[-1], dtype=bool)
     safe_D = jnp.where(diag_mask, 1.0, safe_D)
@@ -82,7 +83,7 @@ def _bwd(res, g):
 
     grad_A = jnp.matmul(U, jnp.matmul(term, Vh))
 
-    return grad_A, None
+    return (grad_A,)
 
 
 safe_svd.defvjp(_fwd, _bwd)
@@ -148,7 +149,8 @@ def kabsch(
     d = jnp.linalg.det(jnp.matmul(V, jnp.swapaxes(U, 1, 2)))
     # Nudge by eps so sign() returns +1/-1 even when det is exactly 0;
     # avoids sign(0) = 0 which would zero out R's last column
-    d_sign = jnp.sign(d + 1e-12)
+    _eps = jnp.finfo(P.dtype).eps
+    d_sign = jnp.sign(d + _eps)
 
     B_diag = jnp.ones((*d_sign.shape, D), dtype=d_sign.dtype).at[..., -1].set(d_sign)
 
@@ -160,7 +162,7 @@ def kabsch(
 
     aligned = jnp.matmul(P, jnp.swapaxes(R, 1, 2)) + t[:, jnp.newaxis, :]
     diff_sq = jnp.sum(jnp.square(aligned - Q), axis=(1, 2)) / N
-    rmsd = jnp.sqrt(jnp.clip(diff_sq, min=1e-12, max=None))
+    rmsd = jnp.sqrt(jnp.clip(diff_sq, min=_eps, max=None))
 
     if is_single:
         R, t, rmsd = R[0], t[0], rmsd[0]
@@ -245,11 +247,12 @@ def kabsch_umeyama(
     d = jnp.linalg.det(jnp.matmul(V, jnp.swapaxes(U, 1, 2)))
     # Nudge by eps so sign() returns +1/-1 even when det is exactly 0;
     # avoids sign(0) = 0 which would zero out R's last column
-    d_sign = jnp.sign(d + 1e-12)
+    _eps = jnp.finfo(P.dtype).eps
+    d_sign = jnp.sign(d + _eps)
 
     S_corr = jnp.ones((*d_sign.shape, D), dtype=d_sign.dtype).at[..., -1].set(d_sign)
 
-    c = jnp.sum(S * S_corr, axis=-1) / jnp.clip(var_P, min=1e-12, max=None)
+    c = jnp.sum(S * S_corr, axis=-1) / jnp.clip(var_P, min=_eps, max=None)
 
     R = jnp.matmul(V * S_corr[:, jnp.newaxis, :], jnp.swapaxes(U, 1, 2))
 
@@ -263,7 +266,7 @@ def kabsch_umeyama(
     )
     rmsd = jnp.sqrt(
         jnp.clip(
-            jnp.sum(jnp.square(aligned_P - Q), axis=(1, 2)) / N, min=1e-12, max=None
+            jnp.sum(jnp.square(aligned_P - Q), axis=(1, 2)) / N, min=_eps, max=None
         )
     )
 

--- a/src/kabsch_horn/mlx/_utils.py
+++ b/src/kabsch_horn/mlx/_utils.py
@@ -2,6 +2,13 @@ import warnings
 
 import mlx.core as mx
 
+_DTYPE_EPS = {
+    mx.float16: 9.765625e-4,
+    mx.bfloat16: 7.8125e-3,
+    mx.float32: 1.1920929e-7,
+    mx.float64: 2.220446049250313e-16,
+}
+
 
 def _warn_if_float64(P: mx.array, Q: mx.array, stacklevel: int = 3) -> None:
     """Emit a UserWarning if either P or Q is float64.

--- a/src/kabsch_horn/mlx/horn_quat_3d.py
+++ b/src/kabsch_horn/mlx/horn_quat_3d.py
@@ -2,6 +2,13 @@ import mlx.core as mx
 
 from ._utils import _warn_if_float64
 
+_DTYPE_EPS = {
+    mx.float16: 9.765625e-4,
+    mx.bfloat16: 7.8125e-3,
+    mx.float32: 1.1920929e-7,
+    mx.float64: 2.220446049250313e-16,
+}
+
 
 @mx.custom_function
 def safe_eigh_fwd(A: mx.array) -> tuple[mx.array, mx.array]:
@@ -21,7 +28,7 @@ def safe_eigh_bwd(primals, cotangents, outputs):
     D = mx.expand_dims(L, -2) - mx.expand_dims(L, -1)
 
     eye = mx.eye(D.shape[-1], dtype=D.dtype)
-    eps = 1e-12
+    eps = _DTYPE_EPS.get(D.dtype, 1.1920929e-7)
     mask = mx.abs(D) < eps
     safe_D = mx.where(mask, mx.where(D >= 0, eps, -eps), D)
     # Set diagonal to 1.0 so 1/safe_D is defined everywhere; zero it out after
@@ -143,7 +150,8 @@ def horn(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
 
     diff = aligned - q
     mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
-    rmsd = mx.sqrt(mx.maximum(mse, 1e-12))
+    _eps = _DTYPE_EPS.get(P.dtype, 1.1920929e-7)
+    rmsd = mx.sqrt(mx.maximum(mse, _eps))
 
     if orig_dtype in (mx.float16, mx.bfloat16):
         R = R.astype(orig_dtype)
@@ -251,7 +259,8 @@ def horn_with_scale(
     )
 
     RH = mx.sum(R * H.swapaxes(-1, -2), axis=(-1, -2))
-    c = RH / mx.maximum(var_P, 1e-12)
+    _eps = _DTYPE_EPS.get(P.dtype, 1.1920929e-7)
+    c = RH / mx.maximum(var_P, _eps)
 
     t = mx.squeeze(centroid_Q, -2) - mx.expand_dims(c, -1) * mx.squeeze(
         mx.matmul(centroid_P, R.swapaxes(-1, -2)), -2
@@ -262,7 +271,7 @@ def horn_with_scale(
     ) + mx.expand_dims(t, -2)
     diff = aligned_P - Q
     mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
-    rmsd = mx.sqrt(mx.maximum(mse, 1e-12))
+    rmsd = mx.sqrt(mx.maximum(mse, _eps))
 
     if orig_dtype in (mx.float16, mx.bfloat16):
         R = R.astype(orig_dtype)

--- a/src/kabsch_horn/mlx/horn_quat_3d.py
+++ b/src/kabsch_horn/mlx/horn_quat_3d.py
@@ -1,13 +1,6 @@
 import mlx.core as mx
 
-from ._utils import _warn_if_float64
-
-_DTYPE_EPS = {
-    mx.float16: 9.765625e-4,
-    mx.bfloat16: 7.8125e-3,
-    mx.float32: 1.1920929e-7,
-    mx.float64: 2.220446049250313e-16,
-}
+from ._utils import _DTYPE_EPS, _warn_if_float64
 
 
 @mx.custom_function

--- a/src/kabsch_horn/mlx/kabsch_svd_nd.py
+++ b/src/kabsch_horn/mlx/kabsch_svd_nd.py
@@ -2,6 +2,13 @@ import mlx.core as mx
 
 from ._utils import _warn_if_float64
 
+_DTYPE_EPS = {
+    mx.float16: 9.765625e-4,
+    mx.bfloat16: 7.8125e-3,
+    mx.float32: 1.1920929e-7,
+    mx.float64: 2.220446049250313e-16,
+}
+
 
 @mx.custom_function
 def safe_svd(A: mx.array) -> tuple[mx.array, mx.array, mx.array]:
@@ -46,8 +53,9 @@ def safe_svd_bwd(primals, cotangents, outputs):
     S_sq_diff = mx.expand_dims(S_sq, -2) - mx.expand_dims(S_sq, -1)
 
     # Add epsilon to diagonal before reciprocal
+    eps = _DTYPE_EPS.get(S_sq_diff.dtype, 1.1920929e-7)
     eye = mx.eye(S_sq_diff.shape[-1], dtype=S_sq_diff.dtype)
-    S_sq_diff_safe = mx.where(mx.abs(S_sq_diff) < 1e-12, eye * 1e-12, S_sq_diff)
+    S_sq_diff_safe = mx.where(mx.abs(S_sq_diff) < eps, eye * eps, S_sq_diff)
 
     F = 1.0 / S_sq_diff_safe
     F = mx.where(eye == 1, mx.zeros_like(F), F)
@@ -166,7 +174,8 @@ def kabsch(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
     P_aligned = mx.matmul(P, R.swapaxes(-1, -2)) + mx.expand_dims(t, -2)
     diff = P_aligned - Q
     mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
-    rmsd = mx.sqrt(mx.maximum(mse, 1e-12))
+    _eps = _DTYPE_EPS.get(P.dtype, 1.1920929e-7)
+    rmsd = mx.sqrt(mx.maximum(mse, _eps))
 
     if orig_dtype in (mx.float16, mx.bfloat16):
         R = R.astype(orig_dtype)
@@ -273,7 +282,8 @@ def kabsch_umeyama(
         axis=-1,
     )
 
-    c = mx.sum(S * S_corr, axis=-1) / mx.maximum(var_P, 1e-12)
+    _eps = _DTYPE_EPS.get(P.dtype, 1.1920929e-7)
+    c = mx.sum(S * S_corr, axis=-1) / mx.maximum(var_P, _eps)
 
     centroid_P_rot = mx.matmul(centroid_P, R.swapaxes(-1, -2))
     t = mx.squeeze(centroid_Q, -2) - mx.expand_dims(c, -1) * mx.squeeze(
@@ -284,7 +294,7 @@ def kabsch_umeyama(
     P_aligned = c_exp * mx.matmul(P, R.swapaxes(-1, -2)) + mx.expand_dims(t, -2)
     diff = P_aligned - Q
     mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
-    rmsd = mx.sqrt(mx.maximum(mse, 1e-12))
+    rmsd = mx.sqrt(mx.maximum(mse, _eps))
 
     if orig_dtype in (mx.float16, mx.bfloat16):
         R = R.astype(orig_dtype)

--- a/src/kabsch_horn/mlx/kabsch_svd_nd.py
+++ b/src/kabsch_horn/mlx/kabsch_svd_nd.py
@@ -1,13 +1,6 @@
 import mlx.core as mx
 
-from ._utils import _warn_if_float64
-
-_DTYPE_EPS = {
-    mx.float16: 9.765625e-4,
-    mx.bfloat16: 7.8125e-3,
-    mx.float32: 1.1920929e-7,
-    mx.float64: 2.220446049250313e-16,
-}
+from ._utils import _DTYPE_EPS, _warn_if_float64
 
 
 @mx.custom_function

--- a/src/kabsch_horn/numpy/horn_quat_3d.py
+++ b/src/kabsch_horn/numpy/horn_quat_3d.py
@@ -203,7 +203,8 @@ def horn_with_scale(
     R = _quat_to_rotation(q_opt)
 
     RH = np.sum(R * H.transpose(0, 2, 1), axis=(1, 2))
-    c = RH / np.clip(var_P, a_min=1e-12, a_max=None)
+    _eps = np.finfo(P.dtype).eps
+    c = RH / np.clip(var_P, a_min=_eps, a_max=None)
 
     t = np.squeeze(centroid_Q, axis=1) - c[:, np.newaxis] * np.squeeze(
         np.matmul(centroid_P, R.transpose(0, 2, 1)), axis=1

--- a/src/kabsch_horn/numpy/kabsch_svd_nd.py
+++ b/src/kabsch_horn/numpy/kabsch_svd_nd.py
@@ -175,7 +175,8 @@ def kabsch_umeyama(
     S_corr = np.stack([np.ones_like(d_sign)] * (D - 1) + [d_sign], axis=-1)  # BxD
 
     # Scale
-    c = np.sum(S * S_corr, axis=-1) / np.clip(var_P, a_min=1e-12, a_max=None)  # B
+    _eps = np.finfo(P.dtype).eps
+    c = np.sum(S * S_corr, axis=-1) / np.clip(var_P, a_min=_eps, a_max=None)  # B
 
     # Optimal rotation
     R = np.matmul(V * S_corr[:, np.newaxis, :], U.transpose(0, 2, 1))  # BxDxD

--- a/src/kabsch_horn/pytorch/horn_quat_3d.py
+++ b/src/kabsch_horn/pytorch/horn_quat_3d.py
@@ -7,16 +7,15 @@ class SafeEigh(torch.autograd.Function):
     """
 
     @staticmethod
-    def forward(ctx, A: torch.Tensor, eps: float = 1e-12):
+    def forward(ctx, A: torch.Tensor):
         L, V = torch.linalg.eigh(A)
         ctx.save_for_backward(L, V)
-        ctx.eps = eps
         return L, V
 
     @staticmethod
     def backward(ctx, grad_L, grad_V):
         L, V = ctx.saved_tensors
-        eps = ctx.eps
+        eps = torch.finfo(L.dtype).eps
 
         grad_L = torch.zeros_like(L) if grad_L is None else grad_L
         grad_V = torch.zeros_like(V) if grad_V is None else grad_V
@@ -41,7 +40,7 @@ class SafeEigh(torch.autograd.Function):
 
         grad_A = torch.matmul(V, torch.matmul(term, V.mH))
 
-        return grad_A, None
+        return (grad_A,)
 
 
 def horn(
@@ -111,7 +110,7 @@ def horn(
     N = torch.cat([top_row, bottom_block], dim=-2)  # Bx4x4
 
     # 3. Extract the quaternion
-    _L, V = SafeEigh.apply(N, 1e-12)
+    _L, V = SafeEigh.apply(N)
     q_opt = V[..., -1]  # Bx4
 
     # 4. Convert to Rotation Matrix
@@ -146,8 +145,9 @@ def horn(
 
     # RMSD
     aligned = torch.matmul(p, R.transpose(1, 2))
+    _eps = torch.finfo(P.dtype).eps
     rmsd = torch.sqrt(
-        torch.clamp(torch.sum(torch.square(aligned - q), dim=(1, 2)) / N_pts, min=1e-12)
+        torch.clamp(torch.sum(torch.square(aligned - q), dim=(1, 2)) / N_pts, min=_eps)
     )
 
     if is_single:
@@ -232,7 +232,7 @@ def horn_with_scale(
 
     N = torch.cat([top_row, bottom_block], dim=-2)
 
-    _L, V = SafeEigh.apply(N, 1e-12)
+    _L, V = SafeEigh.apply(N)
     q_opt = V[..., -1]
 
     qw = q_opt[..., 0]
@@ -259,8 +259,9 @@ def horn_with_scale(
         dim=-2,
     )
 
+    _eps = torch.finfo(P.dtype).eps
     RH = torch.sum(R * H.transpose(-1, -2), dim=(1, 2))
-    c = RH / torch.clamp(var_P, min=1e-12)
+    c = RH / torch.clamp(var_P, min=_eps)
 
     t = centroid_Q.squeeze(1) - c.unsqueeze(-1) * torch.squeeze(
         torch.matmul(centroid_P, R.transpose(1, 2)), 1
@@ -271,7 +272,7 @@ def horn_with_scale(
     ) + t.unsqueeze(1)
     diff = aligned_P - Q
     rmsd = torch.sqrt(
-        torch.clamp(torch.sum(torch.square(diff), dim=(1, 2)) / N_pts, min=1e-12)
+        torch.clamp(torch.sum(torch.square(diff), dim=(1, 2)) / N_pts, min=_eps)
     )
 
     if is_single:

--- a/src/kabsch_horn/pytorch/kabsch_svd_nd.py
+++ b/src/kabsch_horn/pytorch/kabsch_svd_nd.py
@@ -12,7 +12,7 @@ class SafeSVD(torch.autograd.Function):
 
     @staticmethod
     def forward(
-        ctx, A: torch.Tensor, eps: float = 1e-12
+        ctx, A: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         try:
             U, S, Vh = torch.linalg.svd(A)
@@ -26,22 +26,20 @@ class SafeSVD(torch.autograd.Function):
             nan_s = A.new_full((*A.shape[:-2], min(M, N)), float("nan"))
             nan_vh = A.new_full((*A.shape[:-2], A.shape[-1], A.shape[-1]), float("nan"))
             ctx.save_for_backward(nan_u, nan_s, nan_vh)
-            ctx.eps = eps
             return nan_u, nan_s, nan_vh
         # In PyTorch 1.11+, linalg.svd returns Vh (V^T or V^H).
         # We want V for the standard Kabsch logic, so V = Vh.transpose(-2, -1)
         V = Vh.mH  # Conjugate transpose / standard transpose for real.
 
         ctx.save_for_backward(U, S, Vh)
-        ctx.eps = eps
         return U, S, V
 
     @staticmethod
     def backward(
         ctx, grad_U: torch.Tensor, grad_S: torch.Tensor, grad_V: torch.Tensor
-    ) -> tuple[torch.Tensor, None]:
+    ) -> tuple[torch.Tensor]:
         U, S, Vh = ctx.saved_tensors
-        eps = ctx.eps
+        eps = torch.finfo(S.dtype).eps
 
         # Backward pass of SVD for real matrices:
         # A = U S V^T
@@ -63,9 +61,9 @@ class SafeSVD(torch.autograd.Function):
         D = S_sq.unsqueeze(-1) - S_sq.unsqueeze(-2)  # BxDxD
 
         # 3. Safe F matrix computation
-        # eps=1e-12 masks singular value differences below float64 machine precision
-        # (~2e-16) but well above float32 loss (~1e-7), preventing division-by-zero
-        # NaN gradients without distorting the backward signal.
+        # eps = finfo(dtype).eps masks singular value differences at the dtype's
+        # machine precision, preventing division-by-zero NaN gradients without
+        # distorting the backward signal.
         D_abs = torch.abs(D)
         mask = D_abs < eps
 
@@ -97,17 +95,16 @@ class SafeSVD(torch.autograd.Function):
 
         grad_A = torch.matmul(U, torch.matmul(term, Vh))
 
-        return grad_A, None
+        return (grad_A,)
 
 
 def safe_svd(
-    A: torch.Tensor, eps: float = 1e-12
+    A: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Differentiable wrapper for SVD avoiding NaNs.
     Args:
         A: (..., D, D) tensor
-        eps: Small value for numerical stability
     Returns:
         U, S, V  (V, NOT Vh)
     """
@@ -115,7 +112,7 @@ def safe_svd(
     if A.ndim == 2:
         A = A.unsqueeze(0)
 
-    U, S, V = SafeSVD.apply(A, eps)
+    U, S, V = SafeSVD.apply(A)
 
     if len(orig_shape) == 2:
         return U.squeeze(0), S.squeeze(0), V.squeeze(0)
@@ -189,7 +186,7 @@ def kabsch(
     ones = torch.ones_like(d)
 
     # Sign safely mapping 0 determinant to 1.0 instead of 0.0
-    d_sign = torch.sign(d + 1e-12)
+    d_sign = torch.sign(d + torch.finfo(d.dtype).eps)
 
     B_diag = torch.stack([ones] * (D - 1) + [d_sign], dim=-1)  # BxD
 
@@ -198,9 +195,10 @@ def kabsch(
 
     # RMSD (Adding eps for sqrt derivative safety near 0)
     aligned = torch.matmul(p, R.transpose(1, 2))
+    _eps = torch.finfo(P.dtype).eps
     rmsd = torch.sqrt(
         torch.clamp(
-            torch.sum(torch.square(aligned - q), dim=(1, 2)) / P.shape[1], min=1e-12
+            torch.sum(torch.square(aligned - q), dim=(1, 2)) / P.shape[1], min=_eps
         )
     )
 
@@ -294,13 +292,14 @@ def kabsch_umeyama(
 
     # Right-hand coordinate system
     d = torch.det(torch.matmul(V, U.transpose(1, 2)))
-    d_sign = torch.sign(d + 1e-12)
+    d_sign = torch.sign(d + torch.finfo(d.dtype).eps)
 
     ones = torch.ones_like(d_sign)
     S_corr = torch.stack([ones] * (D - 1) + [d_sign], dim=-1)  # BxD
 
     # Scale
-    c = torch.sum(S * S_corr, dim=-1) / torch.clamp(var_P, min=1e-12)
+    _eps = torch.finfo(P.dtype).eps
+    c = torch.sum(S * S_corr, dim=-1) / torch.clamp(var_P, min=_eps)
 
     # Rotation
     R = torch.matmul(V * S_corr.unsqueeze(1), U.transpose(1, 2))
@@ -315,7 +314,7 @@ def kabsch_umeyama(
         P, R.transpose(1, 2)
     ) + t.unsqueeze(1)
     rmsd = torch.sqrt(
-        torch.clamp(torch.sum(torch.square(aligned_P - Q), dim=(1, 2)) / N, min=1e-12)
+        torch.clamp(torch.sum(torch.square(aligned_P - Q), dim=(1, 2)) / N, min=_eps)
     )
 
     if is_single:

--- a/src/kabsch_horn/tensorflow/horn_quat_3d.py
+++ b/src/kabsch_horn/tensorflow/horn_quat_3d.py
@@ -1,14 +1,15 @@
+import numpy as np
 import tensorflow as tf
 
 
-def safe_eigh(A, eps=1e-12):
+def safe_eigh(A):
     return tf.linalg.eigh(A)
 
 
 @tf.custom_gradient
 def call_safe_eigh(A):
     L, V = safe_eigh(A)
-    eps = tf.cast(1e-12, L.dtype)
+    eps = tf.cast(np.finfo(L.dtype.as_numpy_dtype).eps, L.dtype)
 
     def grad(grad_L, grad_V):
         if grad_L is None:
@@ -125,10 +126,9 @@ def horn(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
 
     aligned = tf.matmul(p, R, transpose_b=True)
     N_pts_f = tf.cast(tf.shape(P)[-2], P.dtype)
+    _eps = np.finfo(P.dtype.as_numpy_dtype).eps
     rmsd = tf.sqrt(
-        tf.maximum(
-            tf.reduce_sum(tf.square(aligned - q), axis=[-2, -1]) / N_pts_f, 1e-12
-        )
+        tf.maximum(tf.reduce_sum(tf.square(aligned - q), axis=[-2, -1]) / N_pts_f, _eps)
     )
 
     if is_single:
@@ -228,8 +228,9 @@ def horn_with_scale(
         axis=-2,
     )
 
+    _eps = np.finfo(P.dtype.as_numpy_dtype).eps
     RH = tf.reduce_sum(R * tf.linalg.matrix_transpose(H), axis=[-2, -1])
-    c = RH / tf.maximum(var_P, 1e-12)
+    c = RH / tf.maximum(var_P, _eps)
 
     t = tf.squeeze(centroid_Q, axis=-2) - tf.expand_dims(c, -1) * tf.squeeze(
         tf.matmul(centroid_P, R, transpose_b=True), axis=-2
@@ -240,7 +241,7 @@ def horn_with_scale(
     ) + tf.expand_dims(t, -2)
     diff = aligned_P - Q
     rmsd = tf.sqrt(
-        tf.maximum(tf.reduce_sum(tf.square(diff), axis=[-2, -1]) / N_pts_f, 1e-12)
+        tf.maximum(tf.reduce_sum(tf.square(diff), axis=[-2, -1]) / N_pts_f, _eps)
     )
 
     if is_single:

--- a/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
+++ b/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
@@ -1,3 +1,4 @@
+import numpy as np
 import tensorflow as tf
 
 
@@ -32,7 +33,7 @@ def safe_svd(A: tf.Tensor) -> tuple[tf.Tensor, ...]:
 
         # Safe denominator: replace near-zero differences with eps * sign
         # to prevent 1/0 = inf on off-diagonal entries where S_i ≈ S_j
-        eps = tf.cast(1e-12, S.dtype)
+        eps = tf.cast(np.finfo(S.dtype.as_numpy_dtype).eps, S.dtype)
         mask = tf.abs(S_sq_diff) < eps
         safe_D = tf.where(mask, tf.where(S_sq_diff >= 0, eps, -eps), S_sq_diff)
         safe_D = tf.linalg.set_diag(safe_D, tf.ones_like(tf.linalg.diag_part(safe_D)))
@@ -148,8 +149,9 @@ def kabsch(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]
     # RMSD
     P_aligned = tf.matmul(P, R, transpose_b=True) + tf.expand_dims(t, -2)
     diff = P_aligned - Q
+    _eps = np.finfo(P.dtype.as_numpy_dtype).eps
     mse = tf.reduce_mean(tf.reduce_sum(tf.square(diff), axis=-1), axis=-1)
-    rmsd = tf.sqrt(tf.maximum(mse, 1e-12))
+    rmsd = tf.sqrt(tf.maximum(mse, _eps))
 
     if orig_dtype in (tf.float16, tf.bfloat16):
         R = tf.cast(R, orig_dtype)
@@ -238,7 +240,8 @@ def kabsch_umeyama(
     S_corr = tf.linalg.diag_part(I_reflect)
 
     # Var_P is batched, S is batched. S * S_corr sum over last dim
-    c = tf.reduce_sum(S * S_corr, axis=-1) / tf.maximum(var_P, 1e-12)
+    _eps = np.finfo(P.dtype.as_numpy_dtype).eps
+    c = tf.reduce_sum(S * S_corr, axis=-1) / tf.maximum(var_P, _eps)
 
     # Translation
     # t = mean_Q - c * R @ mean_P
@@ -252,7 +255,7 @@ def kabsch_umeyama(
     P_aligned = c_exp * tf.matmul(P, R, transpose_b=True) + tf.expand_dims(t, -2)
     diff = P_aligned - Q
     mse = tf.reduce_mean(tf.reduce_sum(tf.square(diff), axis=-1), axis=-1)
-    rmsd = tf.sqrt(tf.maximum(mse, 1e-12))
+    rmsd = tf.sqrt(tf.maximum(mse, _eps))
 
     if orig_dtype in (tf.float16, tf.bfloat16):
         R = tf.cast(R, orig_dtype)


### PR DESCRIPTION
## Summary
- Replaces all ~46 hardcoded `1e-12` eps values across all 10 framework source files with dtype-derived machine epsilon
- Backward-pass masking (SafeSVD/SafeEigh): eps derived from singular value / eigenvalue tensor dtype via `finfo`
- Forward-pass clamps (RMSD sqrt, scale division, det sign nudge): eps derived from working tensor dtype
- Removes `eps` parameter from PyTorch `SafeSVD`/`SafeEigh` and JAX `safe_svd`/`safe_eigh` since eps is now internally derived
- MLX uses a `_DTYPE_EPS` lookup dict (MLX lacks `finfo`)
- TF/NumPy use `np.finfo` for dtype resolution

| dtype | finfo.eps | old 1e-12 | effect |
|-------|-----------|-----------|--------|
| float16 | 9.77e-4 | underflows to 0 | now functional |
| bfloat16 | 7.81e-3 | underflows to 0 | now functional |
| float32 | 1.19e-7 | too tight | masks float32 noise properly |
| float64 | 2.22e-16 | too loose | more precise masking |

## Test plan
- [x] Full test suite: 6896 passed, 440 skipped, 4 xfailed (after adding mx.float64 to _DTYPE_EPS)
- [x] `ruff check . && ruff format .` clean
- [x] Gradient verification tests pass across all frameworks and dtypes
- [x] MLX-Float64 tests pass (previously failed with missing float64 eps entry)

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)