### PR TITLE
fix: switch RMSD sqrt guard from max(mse, eps) to mse + eps

### DIFF
--- a/src/kabsch_horn/jax/horn_quat_3d.py
+++ b/src/kabsch_horn/jax/horn_quat_3d.py
@@ -168,13 +168,8 @@ def horn(
 
     aligned = jnp.matmul(p, jnp.swapaxes(R, 1, 2))
     _eps = jnp.finfo(P.dtype).eps
-    rmsd = jnp.sqrt(
-        jnp.clip(
-            jnp.sum(jnp.square(aligned - q), axis=(1, 2)) / N_pts,
-            min=_eps,
-            max=None,
-        )
-    )
+    mse = jnp.sum(jnp.square(aligned - q), axis=(1, 2)) / N_pts
+    rmsd = jnp.sqrt(mse + _eps)
 
     if is_single:
         R, t, rmsd = R[0], t[0], rmsd[0]
@@ -254,9 +249,8 @@ def horn_with_scale(
         + t[:, jnp.newaxis, :]
     )
     diff = aligned_P - Q
-    rmsd = jnp.sqrt(
-        jnp.clip(jnp.sum(jnp.square(diff), axis=(1, 2)) / N_pts, min=_eps, max=None)
-    )
+    mse = jnp.sum(jnp.square(diff), axis=(1, 2)) / N_pts
+    rmsd = jnp.sqrt(mse + _eps)
 
     if is_single:
         R, t, c, rmsd = R[0], t[0], c[0], rmsd[0]

--- a/src/kabsch_horn/jax/kabsch_svd_nd.py
+++ b/src/kabsch_horn/jax/kabsch_svd_nd.py
@@ -161,8 +161,8 @@ def kabsch(
     )
 
     aligned = jnp.matmul(P, jnp.swapaxes(R, 1, 2)) + t[:, jnp.newaxis, :]
-    diff_sq = jnp.sum(jnp.square(aligned - Q), axis=(1, 2)) / N
-    rmsd = jnp.sqrt(jnp.clip(diff_sq, min=_eps, max=None))
+    mse = jnp.sum(jnp.square(aligned - Q), axis=(1, 2)) / N
+    rmsd = jnp.sqrt(mse + _eps)
 
     if is_single:
         R, t, rmsd = R[0], t[0], rmsd[0]
@@ -264,11 +264,8 @@ def kabsch_umeyama(
         c[:, jnp.newaxis, jnp.newaxis] * jnp.matmul(P, jnp.swapaxes(R, 1, 2))
         + t[:, jnp.newaxis, :]
     )
-    rmsd = jnp.sqrt(
-        jnp.clip(
-            jnp.sum(jnp.square(aligned_P - Q), axis=(1, 2)) / N, min=_eps, max=None
-        )
-    )
+    mse = jnp.sum(jnp.square(aligned_P - Q), axis=(1, 2)) / N
+    rmsd = jnp.sqrt(mse + _eps)
 
     if is_single:
         R, t, c, rmsd = R[0], t[0], c[0], rmsd[0]

--- a/src/kabsch_horn/mlx/horn_quat_3d.py
+++ b/src/kabsch_horn/mlx/horn_quat_3d.py
@@ -144,7 +144,7 @@ def horn(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
     diff = aligned - q
     mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
     _eps = _DTYPE_EPS.get(P.dtype, 1.1920929e-7)
-    rmsd = mx.sqrt(mx.maximum(mse, _eps))
+    rmsd = mx.sqrt(mse + _eps)
 
     if orig_dtype in (mx.float16, mx.bfloat16):
         R = R.astype(orig_dtype)
@@ -264,7 +264,7 @@ def horn_with_scale(
     ) + mx.expand_dims(t, -2)
     diff = aligned_P - Q
     mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
-    rmsd = mx.sqrt(mx.maximum(mse, _eps))
+    rmsd = mx.sqrt(mse + _eps)
 
     if orig_dtype in (mx.float16, mx.bfloat16):
         R = R.astype(orig_dtype)

--- a/src/kabsch_horn/mlx/kabsch_svd_nd.py
+++ b/src/kabsch_horn/mlx/kabsch_svd_nd.py
@@ -168,7 +168,7 @@ def kabsch(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
     diff = P_aligned - Q
     mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
     _eps = _DTYPE_EPS.get(P.dtype, 1.1920929e-7)
-    rmsd = mx.sqrt(mx.maximum(mse, _eps))
+    rmsd = mx.sqrt(mse + _eps)
 
     if orig_dtype in (mx.float16, mx.bfloat16):
         R = R.astype(orig_dtype)
@@ -287,7 +287,7 @@ def kabsch_umeyama(
     P_aligned = c_exp * mx.matmul(P, R.swapaxes(-1, -2)) + mx.expand_dims(t, -2)
     diff = P_aligned - Q
     mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
-    rmsd = mx.sqrt(mx.maximum(mse, _eps))
+    rmsd = mx.sqrt(mse + _eps)
 
     if orig_dtype in (mx.float16, mx.bfloat16):
         R = R.astype(orig_dtype)

--- a/src/kabsch_horn/pytorch/horn_quat_3d.py
+++ b/src/kabsch_horn/pytorch/horn_quat_3d.py
@@ -146,9 +146,8 @@ def horn(
     # RMSD
     aligned = torch.matmul(p, R.transpose(1, 2))
     _eps = torch.finfo(P.dtype).eps
-    rmsd = torch.sqrt(
-        torch.clamp(torch.sum(torch.square(aligned - q), dim=(1, 2)) / N_pts, min=_eps)
-    )
+    mse = torch.sum(torch.square(aligned - q), dim=(1, 2)) / N_pts
+    rmsd = torch.sqrt(mse + _eps)
 
     if is_single:
         R, t, rmsd = R[0], t[0], rmsd[0]
@@ -271,9 +270,8 @@ def horn_with_scale(
         P, R.transpose(1, 2)
     ) + t.unsqueeze(1)
     diff = aligned_P - Q
-    rmsd = torch.sqrt(
-        torch.clamp(torch.sum(torch.square(diff), dim=(1, 2)) / N_pts, min=_eps)
-    )
+    mse = torch.sum(torch.square(diff), dim=(1, 2)) / N_pts
+    rmsd = torch.sqrt(mse + _eps)
 
     if is_single:
         R, t, c, rmsd = R[0], t[0], c[0], rmsd[0]

--- a/src/kabsch_horn/pytorch/kabsch_svd_nd.py
+++ b/src/kabsch_horn/pytorch/kabsch_svd_nd.py
@@ -193,14 +193,11 @@ def kabsch(
     # 3. Optimal Rotation: R = V * B_diag * U^T
     R = torch.matmul(V * B_diag.unsqueeze(1), U.transpose(1, 2))  # Bx3x3
 
-    # RMSD (Adding eps for sqrt derivative safety near 0)
+    # RMSD (mse + eps for smooth sqrt gradient near zero)
     aligned = torch.matmul(p, R.transpose(1, 2))
     _eps = torch.finfo(P.dtype).eps
-    rmsd = torch.sqrt(
-        torch.clamp(
-            torch.sum(torch.square(aligned - q), dim=(1, 2)) / P.shape[1], min=_eps
-        )
-    )
+    mse = torch.sum(torch.square(aligned - q), dim=(1, 2)) / P.shape[1]
+    rmsd = torch.sqrt(mse + _eps)
 
     # Fast Translation
     t = centroid_Q.squeeze(1) - torch.squeeze(
@@ -313,9 +310,8 @@ def kabsch_umeyama(
     aligned_P = c.unsqueeze(-1).unsqueeze(-1) * torch.matmul(
         P, R.transpose(1, 2)
     ) + t.unsqueeze(1)
-    rmsd = torch.sqrt(
-        torch.clamp(torch.sum(torch.square(aligned_P - Q), dim=(1, 2)) / N, min=_eps)
-    )
+    mse = torch.sum(torch.square(aligned_P - Q), dim=(1, 2)) / N
+    rmsd = torch.sqrt(mse + _eps)
 
     if is_single:
         R, t, c, rmsd = R[0], t[0], c[0], rmsd[0]

--- a/src/kabsch_horn/tensorflow/horn_quat_3d.py
+++ b/src/kabsch_horn/tensorflow/horn_quat_3d.py
@@ -136,9 +136,8 @@ def horn(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
     aligned = tf.matmul(p, R, transpose_b=True)
     N_pts_f = tf.cast(tf.shape(P)[-2], P.dtype)
     _eps = np.finfo(P.dtype.as_numpy_dtype).eps
-    rmsd = tf.sqrt(
-        tf.maximum(tf.reduce_sum(tf.square(aligned - q), axis=[-2, -1]) / N_pts_f, _eps)
-    )
+    mse = tf.reduce_sum(tf.square(aligned - q), axis=[-2, -1]) / N_pts_f
+    rmsd = tf.sqrt(mse + _eps)
 
     if is_single:
         R, t, rmsd = R[0], t[0], rmsd[0]
@@ -258,9 +257,8 @@ def horn_with_scale(
         P, R, transpose_b=True
     ) + tf.expand_dims(t, -2)
     diff = aligned_P - Q
-    rmsd = tf.sqrt(
-        tf.maximum(tf.reduce_sum(tf.square(diff), axis=[-2, -1]) / N_pts_f, _eps)
-    )
+    mse = tf.reduce_sum(tf.square(diff), axis=[-2, -1]) / N_pts_f
+    rmsd = tf.sqrt(mse + _eps)
 
     if is_single:
         R, t, c, rmsd = R[0], t[0], c[0], rmsd[0]

--- a/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
+++ b/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
@@ -157,7 +157,7 @@ def kabsch(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]
     diff = P_aligned - Q
     _eps = np.finfo(P.dtype.as_numpy_dtype).eps
     mse = tf.reduce_mean(tf.reduce_sum(tf.square(diff), axis=-1), axis=-1)
-    rmsd = tf.sqrt(tf.maximum(mse, _eps))
+    rmsd = tf.sqrt(mse + _eps)
 
     if orig_dtype in (tf.float16, tf.bfloat16):
         R = tf.cast(R, orig_dtype)
@@ -267,7 +267,7 @@ def kabsch_umeyama(
     P_aligned = c_exp * tf.matmul(P, R, transpose_b=True) + tf.expand_dims(t, -2)
     diff = P_aligned - Q
     mse = tf.reduce_mean(tf.reduce_sum(tf.square(diff), axis=-1), axis=-1)
-    rmsd = tf.sqrt(tf.maximum(mse, _eps))
+    rmsd = tf.sqrt(mse + _eps)
 
     if orig_dtype in (tf.float16, tf.bfloat16):
         R = tf.cast(R, orig_dtype)


### PR DESCRIPTION
## Summary

- Replace `sqrt(max(mse, eps))` with `sqrt(mse + eps)` across all autodiff frameworks (PyTorch, JAX, TensorFlow, MLX) -- 16 sites in 8 files
- Eliminates gradient discontinuity at `mse = eps` where gradient jumped from 0 to `1/(2*sqrt(eps))`
- Standard deep learning pattern that provides smooth gradients everywhere with negligible forward-pass bias

Fixes #137

## Test plan

- [x] Full test suite passes (6916 passed, 440 skipped, 4 xfailed)
- [x] `ruff check` and `ruff format` clean
- [ ] Verify no regression in gradient-based tests (`test_gradient_verification.py`, `test_differentiability_traps.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)