### PR TITLE
refactor: cross-framework cleanup

### DIFF
--- a/src/kabsch_horn/jax/horn_quat_3d.py
+++ b/src/kabsch_horn/jax/horn_quat_3d.py
@@ -22,12 +22,12 @@ def _eigh_bwd(res: tuple, g: tuple) -> tuple:
 
     grad_L = (
         jnp.zeros_like(L)
-        if type(grad_L) is jax.custom_derivatives.SymbolicZero
+        if isinstance(grad_L, jax.custom_derivatives.SymbolicZero)
         else grad_L
     )
     grad_V = (
         jnp.zeros_like(V)
-        if type(grad_V) is jax.custom_derivatives.SymbolicZero
+        if isinstance(grad_V, jax.custom_derivatives.SymbolicZero)
         else grad_V
     )
 

--- a/src/kabsch_horn/jax/kabsch_svd_nd.py
+++ b/src/kabsch_horn/jax/kabsch_svd_nd.py
@@ -35,17 +35,17 @@ def _bwd(res, g):
     # Check if None or SymbolicZero
     grad_U = (
         jnp.zeros_like(U)
-        if type(grad_U) is jax.custom_derivatives.SymbolicZero
+        if isinstance(grad_U, jax.custom_derivatives.SymbolicZero)
         else grad_U
     )
     grad_S = (
         jnp.zeros_like(S)
-        if type(grad_S) is jax.custom_derivatives.SymbolicZero
+        if isinstance(grad_S, jax.custom_derivatives.SymbolicZero)
         else grad_S
     )
     grad_V = (
         jnp.zeros_like(Vh)
-        if type(grad_V) is jax.custom_derivatives.SymbolicZero
+        if isinstance(grad_V, jax.custom_derivatives.SymbolicZero)
         else grad_V
     )
 

--- a/src/kabsch_horn/mlx/horn_quat_3d.py
+++ b/src/kabsch_horn/mlx/horn_quat_3d.py
@@ -51,8 +51,8 @@ def horn(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
     avoid NaN gradients when point clouds are symmetric or degenerate.
 
     Args:
-        P: Source points, shape [..., N, 3].
-        Q: Target points, shape [..., N, 3].
+        P: Source points as mx.array, shape [..., N, 3].
+        Q: Target points as mx.array, shape [..., N, 3].
 
     Returns:
         (R, t, rmsd): Rotation [..., 3, 3], translation [..., 3], and RMSD [...].
@@ -161,8 +161,8 @@ def horn_with_scale(
     Strictly 3D only. Uses gradient-safe eigendecomposition (safe_eigh_fwd).
 
     Args:
-        P: Source points, shape [..., N, 3].
-        Q: Target points, shape [..., N, 3].
+        P: Source points as mx.array, shape [..., N, 3].
+        Q: Target points as mx.array, shape [..., N, 3].
 
     Returns:
         (R, t, c, rmsd): Rotation [..., 3, 3], translation [..., 3],

--- a/src/kabsch_horn/mlx/horn_quat_3d.py
+++ b/src/kabsch_horn/mlx/horn_quat_3d.py
@@ -58,8 +58,6 @@ def horn(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
         (R, t, rmsd): Rotation [..., 3, 3], translation [..., 3], and RMSD [...].
         float16/bfloat16 inputs are upcast to float32 internally and downcast on output.
     """
-    P = mx.array(P)
-    Q = mx.array(Q)
     if P.shape != Q.shape:
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
@@ -171,8 +169,6 @@ def horn_with_scale(
         scale [...], RMSD [...].
         float16/bfloat16 inputs are upcast to float32 and downcast on output.
     """
-    P = mx.array(P)
-    Q = mx.array(Q)
     if P.shape != Q.shape:
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
@@ -186,7 +182,6 @@ def horn_with_scale(
     if orig_dtype in (mx.float16, mx.bfloat16):
         P = P.astype(mx.float32)
         Q = Q.astype(mx.float32)
-    N_pts_f = mx.array(P.shape[-2], dtype=P.dtype)
 
     centroid_P = mx.mean(P, axis=-2, keepdims=True)
     centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
@@ -194,9 +189,9 @@ def horn_with_scale(
     p = P - centroid_P
     q = Q - centroid_Q
 
-    var_P = mx.sum(mx.square(p), axis=(-2, -1)) / N_pts_f
+    var_P = mx.sum(mx.square(p), axis=(-2, -1)) / P.shape[-2]
 
-    H = mx.matmul(p.swapaxes(-1, -2), q) / N_pts_f
+    H = mx.matmul(p.swapaxes(-1, -2), q) / P.shape[-2]
 
     S = H + H.swapaxes(-1, -2)
     tr = H[..., 0, 0] + H[..., 1, 1] + H[..., 2, 2]

--- a/src/kabsch_horn/mlx/kabsch_svd_nd.py
+++ b/src/kabsch_horn/mlx/kabsch_svd_nd.py
@@ -225,16 +225,14 @@ def kabsch_umeyama(
         P = P.astype(mx.float32)
         Q = Q.astype(mx.float32)
 
-    N = mx.array(P.shape[-2], dtype=P.dtype)
-
     centroid_P = mx.mean(P, axis=-2, keepdims=True)
     centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
 
     p = P - centroid_P
     q = Q - centroid_Q
 
-    var_P = mx.sum(mx.square(p), axis=(-2, -1)) / N
-    H = mx.matmul(p.swapaxes(-1, -2), q) / N
+    var_P = mx.sum(mx.square(p), axis=(-2, -1)) / P.shape[-2]
+    H = mx.matmul(p.swapaxes(-1, -2), q) / P.shape[-2]
 
     U, S, Vt = safe_svd(H)
 

--- a/src/kabsch_horn/pytorch/horn_quat_3d.py
+++ b/src/kabsch_horn/pytorch/horn_quat_3d.py
@@ -20,6 +20,9 @@ class SafeEigh(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_L, grad_V):
+        if not ctx.needs_input_grad[0]:
+            return (None,)
+
         L, V = ctx.saved_tensors
         eps = torch.finfo(L.dtype).eps
 

--- a/src/kabsch_horn/pytorch/kabsch_svd_nd.py
+++ b/src/kabsch_horn/pytorch/kabsch_svd_nd.py
@@ -109,7 +109,7 @@ def safe_svd(
     """
     Differentiable wrapper for SVD avoiding NaNs.
     Args:
-        A: (..., D, D) tensor (must be at least 3D)
+        A: (..., D, D) tensor (ndim >= 3)
     Returns:
         U, S, V  (V, NOT Vh)
     """

--- a/src/kabsch_horn/pytorch/kabsch_svd_nd.py
+++ b/src/kabsch_horn/pytorch/kabsch_svd_nd.py
@@ -40,6 +40,9 @@ class SafeSVD(torch.autograd.Function):
     def backward(
         ctx, grad_U: torch.Tensor, grad_S: torch.Tensor, grad_V: torch.Tensor
     ) -> tuple[torch.Tensor]:
+        if not ctx.needs_input_grad[0]:
+            return (None,)
+
         U, S, Vh = ctx.saved_tensors
         eps = torch.finfo(S.dtype).eps
 
@@ -106,19 +109,11 @@ def safe_svd(
     """
     Differentiable wrapper for SVD avoiding NaNs.
     Args:
-        A: (..., D, D) tensor
+        A: (..., D, D) tensor (must be at least 3D)
     Returns:
         U, S, V  (V, NOT Vh)
     """
-    orig_shape = A.shape
-    if A.ndim == 2:
-        A = A.unsqueeze(0)
-
-    U, S, V = SafeSVD.apply(A)
-
-    if len(orig_shape) == 2:
-        return U.squeeze(0), S.squeeze(0), V.squeeze(0)
-    return U, S, V
+    return SafeSVD.apply(A)
 
 
 def kabsch(


### PR DESCRIPTION
## Summary

- **#117**: Remove unreachable `ndim==2` branch and squeeze path in PyTorch `safe_svd` (both callers always pass 3D+ tensors)
- **#115**: Add `ctx.needs_input_grad[0]` early return in PyTorch `SafeSVD.backward` and `SafeEigh.backward` to skip computation when input doesn't require gradients
- **#119**: Replace `type(x) is jax.custom_derivatives.SymbolicZero` with `isinstance()` in all 5 JAX backward pass checks (idiomatic, subclass-safe)
- **#122**: Remove unnecessary `mx.array()` scalar construction for division in MLX `kabsch_umeyama` and `horn_with_scale` -- MLX supports array/scalar division natively
- **#121**: Remove `P = mx.array(P); Q = mx.array(Q)` input wrapping from MLX `horn` and `horn_with_scale` for consistency with `kabsch`/`kabsch_umeyama` and other frameworks

No behavioral changes for normal usage. The only observable difference: MLX `horn`/`horn_with_scale` will now raise on non-`mx.array` inputs instead of silently converting.

Closes #117, closes #115, closes #119, closes #122, closes #121.

## Test plan

- [x] `uv run ruff check . && uv run ruff format .` -- all checks passed
- [x] `uv run pytest tests/ -x` -- 6916 passed, 440 skipped, 4 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)