### PR TITLE
docs: docstrings, normalization notes, compile/jit guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ compiled_kabsch = torch.compile(kh.kabsch)
 R, t, rmsd = compiled_kabsch(P, Q)
 ```
 
+The custom autograd functions (`SafeSVD`, `SafeEigh`) act as graph breaks under `torch.compile`, so the compiler cannot fuse operations across the SVD/eigh boundary. Surrounding code is still compiled and optimized.
+
 **JAX** (`jax.jit`):
 
 ```python

--- a/README.md
+++ b/README.md
@@ -75,6 +75,32 @@ loss.mean().backward()
 
 NumPy provides forward-pass evaluation only. MLX uses a hardcoded 3x3 determinant correction and raises `ValueError` for non-3D inputs. JAX float64 requires `JAX_ENABLE_X64=True` to be set before importing JAX, otherwise inputs are silently downcast to float32.
 
+## Compiler and JIT Support
+
+All functions are compatible with `torch.compile` and `jax.jit`. Wrapping is optional -- functions work correctly without it -- but can improve throughput for repeated calls.
+
+**PyTorch** (`torch.compile`):
+
+```python
+import torch
+from kabsch_horn import pytorch as kh
+
+compiled_kabsch = torch.compile(kh.kabsch)
+R, t, rmsd = compiled_kabsch(P, Q)
+```
+
+**JAX** (`jax.jit`):
+
+```python
+import jax
+from kabsch_horn import jax as kh
+
+jitted_kabsch = jax.jit(kh.kabsch)
+R, t, rmsd = jitted_kabsch(P, Q)
+```
+
+JAX float64 requires `JAX_ENABLE_X64=True` to be set before importing JAX, otherwise inputs are silently downcast to float32. This applies whether or not you use `jit`.
+
 ## Two Paths to Alignment
 
 ### Kabsch Algorithm (N-Dimensional SVD)
@@ -132,7 +158,7 @@ When the cross-covariance $H = (P - \bar{P})^\top (Q - \bar{Q})$ is well-conditi
 
 ### Gradient stability
 
-SafeSVD and SafeEigh override the standard backward pass to mask near-zero singular value and eigenvalue differences with `eps=1e-12`. The table below lists the degenerate cases explicitly tested.
+SafeSVD and SafeEigh override the standard backward pass to mask near-zero singular value and eigenvalue differences with `finfo(dtype).eps`. The table below lists the degenerate cases explicitly tested.
 
 | Degenerate input | Guarantee | Test |
 |-----------------|-----------|------|
@@ -190,7 +216,7 @@ The rotation matrix `R` returned by `kabsch` and `horn` is differentiable, so it
 
 To port these algorithms to a new backend, implement the following interface:
 
-1. **`safe_svd(A)`** -- A custom-gradient SVD that masks near-zero singular value differences in the backward pass with `eps=1e-12`. See `src/kabsch_horn/pytorch/kabsch_svd_nd.py` (`SafeSVD`) for the reference implementation.
+1. **`safe_svd(A)`** -- A custom-gradient SVD that masks near-zero singular value differences in the backward pass with `finfo(dtype).eps`. See `src/kabsch_horn/pytorch/kabsch_svd_nd.py` (`SafeSVD`) for the reference implementation.
 2. **`safe_eigh(A)`** -- Same pattern for eigendecomposition, used by Horn's method. See `SafeEigh` in `src/kabsch_horn/pytorch/horn_quat_3d.py`.
 3. **`kabsch(P, Q)`** -- Accepts `[N, D]` or `[..., N, D]` inputs and returns `(R, t, rmsd)`.
 4. **`horn(P, Q)`** -- Accepts `[N, 3]` or `[..., N, 3]` inputs and returns `(R, t, rmsd)`.

--- a/src/kabsch_horn/jax/kabsch_svd_nd.py
+++ b/src/kabsch_horn/jax/kabsch_svd_nd.py
@@ -201,6 +201,10 @@ def kabsch_umeyama(
         float16/bfloat16 inputs are upcast to float32 and downcast on output.
 
     Note:
+        Unlike kabsch, the cross-covariance H is divided by N here. This per-point
+        normalization is required by the Umeyama scale estimator
+        (c = trace(S * D) / var_P) and does not affect the rotation or translation.
+
         R is only stable under global translation and uniform scaling when the
         cross-covariance matrix H = P_c.T @ Q_c is well-conditioned. When the
         smallest singular value of H is near zero, U and V from the SVD are not
@@ -238,6 +242,7 @@ def kabsch_umeyama(
     p = P - centroid_P
     q = Q - centroid_Q
 
+    # Cross-covariance matrix (divided by N for Umeyama scale estimation)
     H = jnp.matmul(jnp.swapaxes(p, 1, 2), q) / N
 
     var_P = jnp.sum(jnp.square(p), axis=(1, 2)) / N

--- a/src/kabsch_horn/mlx/kabsch_svd_nd.py
+++ b/src/kabsch_horn/mlx/kabsch_svd_nd.py
@@ -201,6 +201,10 @@ def kabsch_umeyama(
         ValueError: If inputs are not 3-dimensional (D != 3).
 
     Note:
+        Unlike kabsch, the cross-covariance H is divided by N here. This per-point
+        normalization is required by the Umeyama scale estimator
+        (c = trace(S * D) / var_P) and does not affect the rotation or translation.
+
         R is only stable under global translation and uniform scaling when the
         cross-covariance matrix H = P_c.T @ Q_c is well-conditioned. When the
         smallest singular value of H is near zero, U and V from the SVD are not
@@ -232,6 +236,7 @@ def kabsch_umeyama(
     q = Q - centroid_Q
 
     var_P = mx.sum(mx.square(p), axis=(-2, -1)) / P.shape[-2]
+    # Cross-covariance matrix (divided by N for Umeyama scale estimation)
     H = mx.matmul(p.swapaxes(-1, -2), q) / P.shape[-2]
 
     U, S, Vt = safe_svd(H)

--- a/src/kabsch_horn/numpy/kabsch_svd_nd.py
+++ b/src/kabsch_horn/numpy/kabsch_svd_nd.py
@@ -117,6 +117,10 @@ def kabsch_umeyama(
         RMSD [...].
 
     Note:
+        Unlike kabsch, the cross-covariance H is divided by N here. This per-point
+        normalization is required by the Umeyama scale estimator
+        (c = trace(S * D) / var_P) and does not affect the rotation or translation.
+
         R is only stable under global translation and uniform scaling when the
         cross-covariance matrix H = P_c.T @ Q_c is well-conditioned. When the
         smallest singular value of H is near zero, U and V from the SVD are not
@@ -155,7 +159,7 @@ def kabsch_umeyama(
     p = P - centroid_P  # BxNxD
     q = Q - centroid_Q  # BxNxD
 
-    # Cross-covariance matrix
+    # Cross-covariance matrix (divided by N for Umeyama scale estimation)
     H = np.matmul(p.transpose(0, 2, 1), q) / N  # BxDxD
 
     # Variances

--- a/src/kabsch_horn/pytorch/horn_quat_3d.py
+++ b/src/kabsch_horn/pytorch/horn_quat_3d.py
@@ -214,7 +214,7 @@ def horn_with_scale(
 
     var_P = torch.sum(torch.square(p), dim=(1, 2)) / N_pts
 
-    # Cross-variance matrix
+    # Cross-covariance matrix
     H = torch.matmul(p.transpose(1, 2), q) / N_pts
 
     # S

--- a/src/kabsch_horn/pytorch/kabsch_svd_nd.py
+++ b/src/kabsch_horn/pytorch/kabsch_svd_nd.py
@@ -236,6 +236,10 @@ def kabsch_umeyama(
         RMSD [...].
 
     Note:
+        Unlike kabsch, the cross-covariance H is divided by N here. This per-point
+        normalization is required by the Umeyama scale estimator
+        (c = trace(S * D) / var_P) and does not affect the rotation or translation.
+
         R is only stable under global translation and uniform scaling when the
         cross-covariance matrix H = P_c.T @ Q_c is well-conditioned. When the
         smallest singular value of H is near zero, U and V from the SVD are not
@@ -275,7 +279,7 @@ def kabsch_umeyama(
     p = P - centroid_P
     q = Q - centroid_Q
 
-    # Cross-variance matrix
+    # Cross-covariance matrix (divided by N for Umeyama scale estimation)
     H = torch.matmul(p.transpose(1, 2), q) / N
 
     # Variances of P

--- a/src/kabsch_horn/tensorflow/horn_quat_3d.py
+++ b/src/kabsch_horn/tensorflow/horn_quat_3d.py
@@ -8,7 +8,7 @@ def safe_eigh(A: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor]:
 
 
 @tf.custom_gradient
-def call_safe_eigh(A: tf.Tensor) -> tuple[tuple[tf.Tensor, tf.Tensor], ...]:
+def call_safe_eigh(A: tf.Tensor) -> tuple[tf.Tensor, ...]:
     """Gradient-safe eigendecomposition for symmetric matrices. Masks near-zero
     eigenvalue differences (< eps) in the backward pass to prevent NaN gradients."""
     L, V = safe_eigh(A)

--- a/src/kabsch_horn/tensorflow/horn_quat_3d.py
+++ b/src/kabsch_horn/tensorflow/horn_quat_3d.py
@@ -2,12 +2,15 @@ import numpy as np
 import tensorflow as tf
 
 
-def safe_eigh(A):
+def safe_eigh(A: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor]:
+    """Eigendecomposition of a symmetric matrix. Used by call_safe_eigh."""
     return tf.linalg.eigh(A)
 
 
 @tf.custom_gradient
-def call_safe_eigh(A):
+def call_safe_eigh(A: tf.Tensor) -> tuple[tuple[tf.Tensor, tf.Tensor], ...]:
+    """Gradient-safe eigendecomposition for symmetric matrices. Masks near-zero
+    eigenvalue differences (< eps) in the backward pass to prevent NaN gradients."""
     L, V = safe_eigh(A)
     eps = tf.cast(np.finfo(L.dtype.as_numpy_dtype).eps, L.dtype)
 
@@ -38,6 +41,21 @@ def call_safe_eigh(A):
 
 
 def horn(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
+    """
+    Computes optimal rotation and translation to align P to Q using Horn's
+    quaternion method.
+
+    Strictly 3D only. Uses gradient-safe eigendecomposition (call_safe_eigh) to
+    avoid NaN gradients when point clouds are symmetric or degenerate.
+
+    Args:
+        P: Source points, shape [..., N, 3].
+        Q: Target points, shape [..., N, 3].
+
+    Returns:
+        (R, t, rmsd): Rotation [..., 3, 3], translation [..., 3], and RMSD [...].
+        float16/bfloat16 inputs are upcast to float32 internally and downcast on output.
+    """
     P = tf.convert_to_tensor(P)
     Q = tf.convert_to_tensor(Q)
 
@@ -151,6 +169,21 @@ def horn(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
 def horn_with_scale(
     P: tf.Tensor, Q: tf.Tensor
 ) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor, tf.Tensor]:
+    """
+    Computes optimal rotation, translation, and scale to align P to Q
+    (Q ~ c * R @ P + t).
+
+    Strictly 3D only. Uses gradient-safe eigendecomposition (call_safe_eigh).
+
+    Args:
+        P: Source points, shape [..., N, 3].
+        Q: Target points, shape [..., N, 3].
+
+    Returns:
+        (R, t, c, rmsd): Rotation [..., 3, 3], translation [..., 3],
+        scale [...], RMSD [...].
+        float16/bfloat16 inputs are upcast to float32 and downcast on output.
+    """
     P = tf.convert_to_tensor(P)
     Q = tf.convert_to_tensor(Q)
 

--- a/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
+++ b/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
@@ -182,6 +182,10 @@ def kabsch_umeyama(
         RMSD [...].
 
     Note:
+        Unlike kabsch, the cross-covariance H is divided by N here. This per-point
+        normalization is required by the Umeyama scale estimator
+        (c = trace(S * D) / var_P) and does not affect the rotation or translation.
+
         R is only stable under global translation and uniform scaling when the
         cross-covariance matrix H = P_c.T @ Q_c is well-conditioned. When the
         smallest singular value of H is near zero, U and V from the SVD are not
@@ -218,7 +222,7 @@ def kabsch_umeyama(
         tf.shape(P)[-2], P.dtype
     )
 
-    # Covariance
+    # Cross-covariance matrix (divided by N for Umeyama scale estimation)
     N = tf.cast(tf.shape(P)[-2], P.dtype)
     H = tf.matmul(p, q, transpose_a=True) / N
 


### PR DESCRIPTION
## Summary

- **#129**: Add cross-covariance `/N` normalization note to `kabsch_umeyama` docstrings across all 5 frameworks, explaining why it differs from `kabsch` (Umeyama scale estimator requires per-point covariance)
- **#126**: Add type annotations and docstrings to TensorFlow `horn_quat_3d.py` (`safe_eigh`, `call_safe_eigh`, `horn`, `horn_with_scale`), matching JAX/MLX quality
- **#27 + #28**: Add "Compiler and JIT Support" README section with `torch.compile` and `jax.jit` usage examples
- Fix two stale `eps=1e-12` references in README (now `finfo(dtype).eps` per PR #136)

Closes #129, closes #126, closes #27, closes #28

## Test plan

- [x] `uv run ruff check . && uv run ruff format .` -- all checks passed
- [x] `uv run pytest tests/ -x` -- 6916 passed, 440 skipped, 4 xfailed
- No code changes -- only docstrings and README

🤖 Generated with [Claude Code](https://claude.com/claude-code)