### PR TITLE
perf: replace repeated ones-stack pattern with single-allocation

### DIFF
--- a/src/kabsch_horn/mlx/kabsch_svd_nd.py
+++ b/src/kabsch_horn/mlx/kabsch_svd_nd.py
@@ -273,10 +273,7 @@ def kabsch_umeyama(
 
     R = mx.matmul(I_reflect_V, U.swapaxes(-1, -2))
 
-    S_corr = mx.concatenate(
-        [mx.ones((*S.shape[:-1], D - 1), dtype=P.dtype), mx.expand_dims(d_sign, -1)],
-        axis=-1,
-    )
+    S_corr = diag
 
     _eps = _DTYPE_EPS.get(P.dtype, 1.1920929e-7)
     c = mx.sum(S * S_corr, axis=-1) / mx.maximum(var_P, _eps)

--- a/src/kabsch_horn/numpy/kabsch_svd_nd.py
+++ b/src/kabsch_horn/numpy/kabsch_svd_nd.py
@@ -65,11 +65,10 @@ def kabsch(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.nda
     d_sign = np.where(d == 0, 1.0, np.sign(d))
 
     # Optimal rotation
+    B_diag = np.ones((*d_sign.shape, D), dtype=P.dtype)
+    B_diag[..., -1] = d_sign
     R = np.matmul(
-        Vt.transpose(0, 2, 1)
-        * np.stack([np.ones_like(d_sign)] * (D - 1) + [d_sign], axis=-1)[
-            :, np.newaxis, :
-        ],
+        Vt.transpose(0, 2, 1) * B_diag[:, np.newaxis, :],
         U.transpose(0, 2, 1),
     )
 
@@ -176,7 +175,8 @@ def kabsch_umeyama(
     d_sign = np.where(d == 0, 1.0, np.sign(d))
 
     # S factor
-    S_corr = np.stack([np.ones_like(d_sign)] * (D - 1) + [d_sign], axis=-1)  # BxD
+    S_corr = np.ones((*d_sign.shape, D), dtype=P.dtype)
+    S_corr[..., -1] = d_sign
 
     # Scale
     _eps = np.finfo(P.dtype).eps

--- a/src/kabsch_horn/pytorch/kabsch_svd_nd.py
+++ b/src/kabsch_horn/pytorch/kabsch_svd_nd.py
@@ -179,13 +179,12 @@ def kabsch(
     # (Checking for reflections)
     d = torch.linalg.det(torch.matmul(V, U.transpose(1, 2)))  # B
 
-    # 2. Build B_diag (safely without in-place mutation for Autograd)
-    ones = torch.ones_like(d)
-
+    # 2. Build B_diag
     # Sign safely mapping 0 determinant to 1.0 instead of 0.0
     d_sign = torch.sign(d + torch.finfo(d.dtype).eps)
 
-    B_diag = torch.stack([ones] * (D - 1) + [d_sign], dim=-1)  # BxD
+    B_diag = torch.ones(*d_sign.shape, D, dtype=P.dtype, device=P.device)
+    B_diag[..., -1] = d_sign
 
     # 3. Optimal Rotation: R = V * B_diag * U^T
     R = torch.matmul(V * B_diag.unsqueeze(1), U.transpose(1, 2))  # Bx3x3
@@ -292,8 +291,8 @@ def kabsch_umeyama(
     d = torch.linalg.det(torch.matmul(V, U.transpose(1, 2)))
     d_sign = torch.sign(d + torch.finfo(d.dtype).eps)
 
-    ones = torch.ones_like(d_sign)
-    S_corr = torch.stack([ones] * (D - 1) + [d_sign], dim=-1)  # BxD
+    S_corr = torch.ones(*d_sign.shape, D, dtype=P.dtype, device=P.device)
+    S_corr[..., -1] = d_sign
 
     # Scale
     _eps = torch.finfo(P.dtype).eps

--- a/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
+++ b/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
@@ -132,12 +132,10 @@ def kabsch(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]
     d_sign = tf.sign(det)
     d_sign = tf.where(d_sign == 0, tf.ones_like(d_sign), d_sign)
 
-    # Process batched tensors differently if P is batched or unbatched
-    # We construct a diagonal array
-    ones = tf.ones_like(d_sign)
+    # Build reflection diagonal: [1, 1, ..., d_sign]
     diag_vals = tf.concat(
         [
-            tf.repeat(tf.expand_dims(ones, -1), dim - 1, axis=-1),
+            tf.ones(tf.concat([tf.shape(d_sign), [dim - 1]], 0), dtype=d_sign.dtype),
             tf.expand_dims(d_sign, -1),
         ],
         axis=-1,
@@ -239,10 +237,9 @@ def kabsch_umeyama(
     d_sign = tf.sign(det)
     d_sign = tf.where(d_sign == 0, tf.ones_like(d_sign), d_sign)
 
-    ones = tf.ones_like(d_sign)
     diag_vals = tf.concat(
         [
-            tf.repeat(tf.expand_dims(ones, -1), dim - 1, axis=-1),
+            tf.ones(tf.concat([tf.shape(d_sign), [dim - 1]], 0), dtype=d_sign.dtype),
             tf.expand_dims(d_sign, -1),
         ],
         axis=-1,


### PR DESCRIPTION
## Summary

- Replace `stack([ones] * (D-1) + [d_sign])` pattern with single `ones()` allocation + index assignment (NumPy, PyTorch) or direct `tf.ones(shape)` + `tf.concat` (TensorFlow)
- MLX `kabsch_umeyama`: reuse existing `diag` array for `S_corr` instead of constructing a redundant copy
- JAX already used the single-allocation pattern (`.at[..., -1].set()`) -- no change needed

Fixes #30

## Changes by framework

| Framework | Before | After |
|-----------|--------|-------|
| NumPy | `np.stack([np.ones_like(d_sign)] * (D-1) + [d_sign])` | `np.ones(shape); arr[..., -1] = d_sign` |
| PyTorch | `torch.stack([ones] * (D-1) + [d_sign])` | `torch.ones(shape); arr[..., -1] = d_sign` |
| TensorFlow | `tf.ones_like` + `tf.repeat` + `tf.expand_dims` + `tf.concat` | `tf.ones(shape)` + `tf.concat` |
| MLX | Redundant `S_corr = mx.concatenate(...)` | Reuse `diag` variable |
| JAX | Already single-allocation | No change |

## Test plan

- [x] Full test suite: 6916 passed, 440 skipped, 4 xfailed, 0 failed
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)