### PR TITLE
fix(ci): correct actions/deploy-pages SHA in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,5 +48,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac590b76de0  # v4
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4
         id: deployment


### PR DESCRIPTION
## Summary

- Fix invalid `actions/deploy-pages` SHA that caused the docs deploy job to fail on push to main
- The pinned SHA `d6db90164ac5ed86f2b6aed7e0febac590b76de0` doesn't exist; corrected to `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` (v4.0.5)

## Test plan

- [ ] Docs workflow deploy job succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)