### PR TITLE
test: add NumPy adapter to test framework matrix

### DIFF
--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -548,6 +548,7 @@ except ImportError:
     _MLX_AVAILABLE = False
 
 
+# NumPy is always available -- no try/except needed
 class NumPyAdapter(FrameworkAdapter[np.ndarray]):
     _DTYPE_MAP: ClassVar[dict[str, np.dtype]] = {
         "float16": np.float16,

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -4,6 +4,8 @@ from typing import ClassVar, Generic, TypeVar
 import numpy as np
 import pytest
 
+from kabsch_horn import numpy as kabsch_np
+
 T = TypeVar("T")
 
 
@@ -55,6 +57,11 @@ class FrameworkAdapter(Generic[T]):
     @property
     def supports_nan_input(self) -> bool:
         """Returns True if the framework propagates NaN through SVD without crashing."""
+        return True
+
+    @property
+    def supports_grad(self) -> bool:
+        """Returns True if the framework supports automatic differentiation."""
         return True
 
     def convert_in(self, arr: np.ndarray) -> T:
@@ -541,7 +548,61 @@ except ImportError:
     _MLX_AVAILABLE = False
 
 
+class NumPyAdapter(FrameworkAdapter[np.ndarray]):
+    _DTYPE_MAP: ClassVar[dict[str, np.dtype]] = {
+        "float16": np.float16,
+        "float32": np.float32,
+        "float64": np.float64,
+    }
+
+    @property
+    def supports_grad(self) -> bool:
+        return False
+
+    @property
+    def supports_nan_input(self) -> bool:
+        # NumPy's SVD raises LinAlgError on NaN inputs
+        return False
+
+    def convert_in(self, arr: np.ndarray) -> np.ndarray:
+        dtype = self._DTYPE_MAP[self.precision]
+        return arr.astype(dtype)
+
+    def convert_in_with_dtype(self, arr: np.ndarray, precision: str) -> np.ndarray:
+        dtype = self._DTYPE_MAP[precision]
+        return arr.astype(dtype)
+
+    def convert_out(self, obj: np.ndarray) -> np.ndarray:
+        if obj.dtype == np.float16:
+            obj = obj.astype(np.float32)
+        return obj
+
+    def kabsch(self, P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, ...]:
+        return kabsch_np.kabsch(P, Q)
+
+    def kabsch_umeyama(self, P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, ...]:
+        return kabsch_np.kabsch_umeyama(P, Q)
+
+    def horn(self, P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, ...]:
+        return kabsch_np.horn(P, Q)
+
+    def horn_with_scale(self, P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, ...]:
+        return kabsch_np.horn_with_scale(P, Q)
+
+    def is_nan(self, tensor: np.ndarray) -> bool:
+        return np.isnan(tensor).any()
+
+    @property
+    def mismatch_exception_type(
+        self,
+    ) -> type[Exception] | tuple[type[Exception], ...]:
+        return ValueError
+
+
 frameworks = [
+    pytest.param(NumPyAdapter("float16"), id="NumPy-Float16"),
+    pytest.param(NumPyAdapter("float32"), id="NumPy-Float32"),
+    pytest.param(NumPyAdapter("float64"), id="NumPy-Float64"),
     *(
         [
             pytest.param(PyTorchAdapter("bfloat16"), id="PyTorch-BFloat16"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,9 +164,10 @@ def pytest_collection_modifyitems(session, config, items) -> None:
     Filters out tests where the requested framework adapter
     does not support the requested spatial dimension.
 
-    When ``--full`` is not passed, also skips float16/bfloat16 adapter tests
-    except for dtype-preservation tests (which exist specifically to verify
-    the upcast path).
+    Also drops gradient-only test modules for forward-only adapters
+    (e.g. NumPy), and when ``--full`` is not passed, skips
+    float16/bfloat16 adapter tests except for dtype-preservation tests
+    (which exist specifically to verify the upcast path).
 
     Note: Hypothesis tests parametrised by `adapter` but with `dim` drawn
     inside `@given` are not filtered here -- they guard themselves with

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,6 +178,15 @@ def pytest_collection_modifyitems(session, config, items) -> None:
         # Check if the test has a callspec (i.e. is parametrized)
         if hasattr(item, "callspec"):
             params = item.callspec.params
+            # Skip gradient-only test modules for forward-only adapters
+            if "adapter" in params and not params["adapter"].supports_grad:
+                module_name = item.module.__name__
+                if module_name in {
+                    "test_differentiability_traps",
+                    "test_gradient_verification",
+                    "test_rmsd_wrappers",
+                }:
+                    continue
             # Skip MLX on unsupported dims,
             # unless the test explicitly checks rejection behaviour.
             if "dim" in params and "adapter" in params:


### PR DESCRIPTION
## Summary
- Adds `NumPyAdapter` to the parametrized test matrix so property tests (orthogonality, det=+1, RMSD optimality, batch behavior, edge cases) now run against NumPy alongside PyTorch, JAX, TensorFlow, and MLX
- Adds `supports_grad` property to `FrameworkAdapter` base class; gradient-only test modules are dropped from collection for forward-only adapters (NumPy)
- Sets `supports_nan_input=False` for NumPy since its SVD raises `LinAlgError` on NaN inputs

Closes #158

## Test plan
- [x] `uv run pytest tests/` passes (4854 passed, 140 skipped, 4 xfailed)
- [x] Gradient tests (`test_differentiability_traps`, `test_gradient_verification`, `test_rmsd_wrappers`) are NOT collected for NumPy
- [x] Forward-pass tests ARE collected for NumPy (Float16, Float32, Float64)
- [x] `uv run ruff check . && uv run ruff format .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)