### PR TITLE
fix: MLX SVD backward, global device leak, and NaN abort

### DIFF
--- a/src/kabsch_horn/mlx/_utils.py
+++ b/src/kabsch_horn/mlx/_utils.py
@@ -1,4 +1,5 @@
 import warnings
+from contextlib import contextmanager
 
 import mlx.core as mx
 
@@ -13,10 +14,8 @@ _DTYPE_EPS = {
 def _warn_if_float64(P: mx.array, Q: mx.array, stacklevel: int = 3) -> None:
     """Emit a UserWarning if either P or Q is float64.
 
-    MLX does not support float64 on GPU. Passing float64 inputs sets the
-    process-wide default device to CPU (mx.set_default_device(mx.cpu)).
-    This is a persistent side effect: all subsequent MLX operations in the
-    process will also run on CPU until the default device is changed again.
+    MLX does not support float64 on GPU. When float64 inputs are detected,
+    operations are temporarily routed to CPU via _float64_device_guard.
     stacklevel=3 is correct for direct callers (kabsch, horn, etc.).
     For rmsd wrappers (kabsch_rmsd -> kabsch -> here), stacklevel points
     one level into the wrapper rather than the user call site; this is an
@@ -24,11 +23,26 @@ def _warn_if_float64(P: mx.array, Q: mx.array, stacklevel: int = 3) -> None:
     """
     if P.dtype == mx.float64 or Q.dtype == mx.float64:
         warnings.warn(
-            "MLX does not support float64 on GPU; falling back to CPU. "
-            "This sets the process-wide default device to CPU "
-            "(mx.set_default_device(mx.cpu)) and will affect all subsequent "
-            "MLX operations in this process.",
+            "MLX does not support float64 on GPU; operations will temporarily "
+            "run on CPU for this call.",
             UserWarning,
             stacklevel=stacklevel,
         )
+
+
+@contextmanager
+def _float64_device_guard(*tensors):
+    """Temporarily set the default device to CPU if any tensor is float64.
+
+    Restores the original default device on exit.
+    """
+    needs_cpu = any(t.dtype == mx.float64 for t in tensors)
+    if needs_cpu:
+        original = mx.default_device()
         mx.set_default_device(mx.cpu)
+        try:
+            yield
+        finally:
+            mx.set_default_device(original)
+    else:
+        yield

--- a/src/kabsch_horn/mlx/_utils.py
+++ b/src/kabsch_horn/mlx/_utils.py
@@ -31,10 +31,12 @@ def _warn_if_float64(P: mx.array, Q: mx.array, stacklevel: int = 3) -> None:
 
 
 @contextmanager
-def _float64_device_guard(*tensors):
+def _float64_device_guard(*tensors: mx.array):
     """Temporarily set the default device to CPU if any tensor is float64.
 
-    Restores the original default device on exit.
+    Restores the original default device on exit. Note: mx.set_default_device
+    is process-global, so this guard is not thread-safe. This is acceptable
+    for typical single-threaded MLX usage.
     """
     needs_cpu = any(t.dtype == mx.float64 for t in tensors)
     if needs_cpu:

--- a/src/kabsch_horn/mlx/horn_quat_3d.py
+++ b/src/kabsch_horn/mlx/horn_quat_3d.py
@@ -1,10 +1,16 @@
 import mlx.core as mx
 
-from ._utils import _DTYPE_EPS, _warn_if_float64
+from ._utils import _DTYPE_EPS, _float64_device_guard, _warn_if_float64
 
 
 @mx.custom_function
 def safe_eigh_fwd(A: mx.array) -> tuple[mx.array, mx.array]:
+    mx.eval(A)
+    if mx.any(mx.isnan(A)).item():
+        n = A.shape[-1]
+        nan_l = mx.full((*A.shape[:-2], n), float("nan"), dtype=A.dtype)
+        nan_v = mx.full_like(A, float("nan"))
+        return nan_l, nan_v
     L, V = mx.linalg.eigh(A, stream=mx.cpu)
     return L, V
 
@@ -67,94 +73,96 @@ def horn(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
         raise ValueError("Horn's method is strictly for 3D point clouds")
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
-    orig_dtype = P.dtype
-    if P.dtype != Q.dtype:
-        # Mixed dtypes: promote to higher precision
-        target = mx.float64 if mx.float64 in (P.dtype, Q.dtype) else mx.float32
-        P = P.astype(target)
-        Q = Q.astype(target)
-        orig_dtype = target
-    elif orig_dtype in (mx.float16, mx.bfloat16):
-        P = P.astype(mx.float32)
-        Q = Q.astype(mx.float32)
 
-    centroid_P = mx.mean(P, axis=-2, keepdims=True)
-    centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
+    with _float64_device_guard(P, Q):
+        orig_dtype = P.dtype
+        if P.dtype != Q.dtype:
+            # Mixed dtypes: promote to higher precision
+            target = mx.float64 if mx.float64 in (P.dtype, Q.dtype) else mx.float32
+            P = P.astype(target)
+            Q = Q.astype(target)
+            orig_dtype = target
+        elif orig_dtype in (mx.float16, mx.bfloat16):
+            P = P.astype(mx.float32)
+            Q = Q.astype(mx.float32)
 
-    p = P - centroid_P
-    q = Q - centroid_Q
+        centroid_P = mx.mean(P, axis=-2, keepdims=True)
+        centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
 
-    H = mx.matmul(p.swapaxes(-1, -2), q)
+        p = P - centroid_P
+        q = Q - centroid_Q
 
-    S = H + H.swapaxes(-1, -2)
-    tr = H[..., 0, 0] + H[..., 1, 1] + H[..., 2, 2]
+        H = mx.matmul(p.swapaxes(-1, -2), q)
 
-    Delta = mx.stack(
-        [
-            H[..., 1, 2] - H[..., 2, 1],
-            H[..., 2, 0] - H[..., 0, 2],
-            H[..., 0, 1] - H[..., 1, 0],
-        ],
-        axis=-1,
-    )
+        S = H + H.swapaxes(-1, -2)
+        tr = H[..., 0, 0] + H[..., 1, 1] + H[..., 2, 2]
 
-    D_dim = 3
-    I_shape = (*H.shape[:-2], D_dim, D_dim)
-    I3 = mx.expand_dims(mx.eye(D_dim, dtype=H.dtype), list(range(len(I_shape) - 2)))
-    I3 = mx.broadcast_to(I3, I_shape)
+        Delta = mx.stack(
+            [
+                H[..., 1, 2] - H[..., 2, 1],
+                H[..., 2, 0] - H[..., 0, 2],
+                H[..., 0, 1] - H[..., 1, 0],
+            ],
+            axis=-1,
+        )
 
-    tr_exp = mx.expand_dims(tr, -1)
-    top_row = mx.expand_dims(mx.concatenate([tr_exp, Delta], axis=-1), -2)
+        D_dim = 3
+        I_shape = (*H.shape[:-2], D_dim, D_dim)
+        I3 = mx.expand_dims(mx.eye(D_dim, dtype=H.dtype), list(range(len(I_shape) - 2)))
+        I3 = mx.broadcast_to(I3, I_shape)
 
-    bottom_block = mx.concatenate(
-        [mx.expand_dims(Delta, -1), S - mx.expand_dims(tr_exp, -1) * I3], axis=-1
-    )
+        tr_exp = mx.expand_dims(tr, -1)
+        top_row = mx.expand_dims(mx.concatenate([tr_exp, Delta], axis=-1), -2)
 
-    N_mat = mx.concatenate([top_row, bottom_block], axis=-2)
+        bottom_block = mx.concatenate(
+            [mx.expand_dims(Delta, -1), S - mx.expand_dims(tr_exp, -1) * I3], axis=-1
+        )
 
-    _L, V = safe_eigh_fwd(N_mat)
-    q_opt = V[..., -1]
+        N_mat = mx.concatenate([top_row, bottom_block], axis=-2)
 
-    qw = q_opt[..., 0]
-    qx = q_opt[..., 1]
-    qy = q_opt[..., 2]
-    qz = q_opt[..., 3]
+        _L, V = safe_eigh_fwd(N_mat)
+        q_opt = V[..., -1]
 
-    R11 = 1 - 2 * (qy**2 + qz**2)
-    R12 = 2 * (qx * qy - qw * qz)
-    R13 = 2 * (qx * qz + qw * qy)
-    R21 = 2 * (qx * qy + qw * qz)
-    R22 = 1 - 2 * (qx**2 + qz**2)
-    R23 = 2 * (qy * qz - qw * qx)
-    R31 = 2 * (qx * qz - qw * qy)
-    R32 = 2 * (qy * qz + qw * qx)
-    R33 = 1 - 2 * (qx**2 + qy**2)
+        qw = q_opt[..., 0]
+        qx = q_opt[..., 1]
+        qy = q_opt[..., 2]
+        qz = q_opt[..., 3]
 
-    R = mx.stack(
-        [
-            mx.stack([R11, R12, R13], axis=-1),
-            mx.stack([R21, R22, R23], axis=-1),
-            mx.stack([R31, R32, R33], axis=-1),
-        ],
-        axis=-2,
-    )
+        R11 = 1 - 2 * (qy**2 + qz**2)
+        R12 = 2 * (qx * qy - qw * qz)
+        R13 = 2 * (qx * qz + qw * qy)
+        R21 = 2 * (qx * qy + qw * qz)
+        R22 = 1 - 2 * (qx**2 + qz**2)
+        R23 = 2 * (qy * qz - qw * qx)
+        R31 = 2 * (qx * qz - qw * qy)
+        R32 = 2 * (qy * qz + qw * qx)
+        R33 = 1 - 2 * (qx**2 + qy**2)
 
-    t = mx.squeeze(centroid_Q, -2) - mx.squeeze(
-        mx.matmul(centroid_P, R.swapaxes(-1, -2)), -2
-    )
+        R = mx.stack(
+            [
+                mx.stack([R11, R12, R13], axis=-1),
+                mx.stack([R21, R22, R23], axis=-1),
+                mx.stack([R31, R32, R33], axis=-1),
+            ],
+            axis=-2,
+        )
 
-    aligned = mx.matmul(p, R.swapaxes(-1, -2))
+        t = mx.squeeze(centroid_Q, -2) - mx.squeeze(
+            mx.matmul(centroid_P, R.swapaxes(-1, -2)), -2
+        )
 
-    diff = aligned - q
-    mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
-    _eps = _DTYPE_EPS.get(P.dtype, 1.1920929e-7)
-    rmsd = mx.sqrt(mse + _eps)
+        aligned = mx.matmul(p, R.swapaxes(-1, -2))
 
-    if orig_dtype in (mx.float16, mx.bfloat16):
-        R = R.astype(orig_dtype)
-        t = t.astype(orig_dtype)
-        rmsd = rmsd.astype(orig_dtype)
-    return R, t, rmsd
+        diff = aligned - q
+        mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
+        _eps = _DTYPE_EPS.get(P.dtype, 1.1920929e-7)
+        rmsd = mx.sqrt(mse + _eps)
+
+        if orig_dtype in (mx.float16, mx.bfloat16):
+            R = R.astype(orig_dtype)
+            t = t.astype(orig_dtype)
+            rmsd = rmsd.astype(orig_dtype)
+        return R, t, rmsd
 
 
 def horn_with_scale(
@@ -184,98 +192,100 @@ def horn_with_scale(
         raise ValueError("Horn's method is strictly for 3D point clouds")
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
-    orig_dtype = P.dtype
-    if P.dtype != Q.dtype:
-        # Mixed dtypes: promote to higher precision
-        target = mx.float64 if mx.float64 in (P.dtype, Q.dtype) else mx.float32
-        P = P.astype(target)
-        Q = Q.astype(target)
-        orig_dtype = target
-    elif orig_dtype in (mx.float16, mx.bfloat16):
-        P = P.astype(mx.float32)
-        Q = Q.astype(mx.float32)
 
-    centroid_P = mx.mean(P, axis=-2, keepdims=True)
-    centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
+    with _float64_device_guard(P, Q):
+        orig_dtype = P.dtype
+        if P.dtype != Q.dtype:
+            # Mixed dtypes: promote to higher precision
+            target = mx.float64 if mx.float64 in (P.dtype, Q.dtype) else mx.float32
+            P = P.astype(target)
+            Q = Q.astype(target)
+            orig_dtype = target
+        elif orig_dtype in (mx.float16, mx.bfloat16):
+            P = P.astype(mx.float32)
+            Q = Q.astype(mx.float32)
 
-    p = P - centroid_P
-    q = Q - centroid_Q
+        centroid_P = mx.mean(P, axis=-2, keepdims=True)
+        centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
 
-    var_P = mx.sum(mx.square(p), axis=(-2, -1)) / P.shape[-2]
+        p = P - centroid_P
+        q = Q - centroid_Q
 
-    H = mx.matmul(p.swapaxes(-1, -2), q) / P.shape[-2]
+        var_P = mx.sum(mx.square(p), axis=(-2, -1)) / P.shape[-2]
 
-    S = H + H.swapaxes(-1, -2)
-    tr = H[..., 0, 0] + H[..., 1, 1] + H[..., 2, 2]
+        H = mx.matmul(p.swapaxes(-1, -2), q) / P.shape[-2]
 
-    Delta = mx.stack(
-        [
-            H[..., 1, 2] - H[..., 2, 1],
-            H[..., 2, 0] - H[..., 0, 2],
-            H[..., 0, 1] - H[..., 1, 0],
-        ],
-        axis=-1,
-    )
+        S = H + H.swapaxes(-1, -2)
+        tr = H[..., 0, 0] + H[..., 1, 1] + H[..., 2, 2]
 
-    D_dim = 3
-    I_shape = (*H.shape[:-2], D_dim, D_dim)
-    I3 = mx.expand_dims(mx.eye(D_dim, dtype=H.dtype), list(range(len(I_shape) - 2)))
-    I3 = mx.broadcast_to(I3, I_shape)
+        Delta = mx.stack(
+            [
+                H[..., 1, 2] - H[..., 2, 1],
+                H[..., 2, 0] - H[..., 0, 2],
+                H[..., 0, 1] - H[..., 1, 0],
+            ],
+            axis=-1,
+        )
 
-    tr_exp = mx.expand_dims(tr, -1)
-    top_row = mx.expand_dims(mx.concatenate([tr_exp, Delta], axis=-1), -2)
+        D_dim = 3
+        I_shape = (*H.shape[:-2], D_dim, D_dim)
+        I3 = mx.expand_dims(mx.eye(D_dim, dtype=H.dtype), list(range(len(I_shape) - 2)))
+        I3 = mx.broadcast_to(I3, I_shape)
 
-    bottom_block = mx.concatenate(
-        [mx.expand_dims(Delta, -1), S - mx.expand_dims(tr_exp, -1) * I3], axis=-1
-    )
+        tr_exp = mx.expand_dims(tr, -1)
+        top_row = mx.expand_dims(mx.concatenate([tr_exp, Delta], axis=-1), -2)
 
-    N_mat = mx.concatenate([top_row, bottom_block], axis=-2)
+        bottom_block = mx.concatenate(
+            [mx.expand_dims(Delta, -1), S - mx.expand_dims(tr_exp, -1) * I3], axis=-1
+        )
 
-    _L, V = safe_eigh_fwd(N_mat)
-    q_opt = V[..., -1]
+        N_mat = mx.concatenate([top_row, bottom_block], axis=-2)
 
-    qw = q_opt[..., 0]
-    qx = q_opt[..., 1]
-    qy = q_opt[..., 2]
-    qz = q_opt[..., 3]
+        _L, V = safe_eigh_fwd(N_mat)
+        q_opt = V[..., -1]
 
-    R11 = 1 - 2 * (qy**2 + qz**2)
-    R12 = 2 * (qx * qy - qw * qz)
-    R13 = 2 * (qx * qz + qw * qy)
-    R21 = 2 * (qx * qy + qw * qz)
-    R22 = 1 - 2 * (qx**2 + qz**2)
-    R23 = 2 * (qy * qz - qw * qx)
-    R31 = 2 * (qx * qz - qw * qy)
-    R32 = 2 * (qy * qz + qw * qx)
-    R33 = 1 - 2 * (qx**2 + qy**2)
+        qw = q_opt[..., 0]
+        qx = q_opt[..., 1]
+        qy = q_opt[..., 2]
+        qz = q_opt[..., 3]
 
-    R = mx.stack(
-        [
-            mx.stack([R11, R12, R13], axis=-1),
-            mx.stack([R21, R22, R23], axis=-1),
-            mx.stack([R31, R32, R33], axis=-1),
-        ],
-        axis=-2,
-    )
+        R11 = 1 - 2 * (qy**2 + qz**2)
+        R12 = 2 * (qx * qy - qw * qz)
+        R13 = 2 * (qx * qz + qw * qy)
+        R21 = 2 * (qx * qy + qw * qz)
+        R22 = 1 - 2 * (qx**2 + qz**2)
+        R23 = 2 * (qy * qz - qw * qx)
+        R31 = 2 * (qx * qz - qw * qy)
+        R32 = 2 * (qy * qz + qw * qx)
+        R33 = 1 - 2 * (qx**2 + qy**2)
 
-    RH = mx.sum(R * H.swapaxes(-1, -2), axis=(-1, -2))
-    _eps = _DTYPE_EPS.get(P.dtype, 1.1920929e-7)
-    c = RH / mx.maximum(var_P, _eps)
+        R = mx.stack(
+            [
+                mx.stack([R11, R12, R13], axis=-1),
+                mx.stack([R21, R22, R23], axis=-1),
+                mx.stack([R31, R32, R33], axis=-1),
+            ],
+            axis=-2,
+        )
 
-    t = mx.squeeze(centroid_Q, -2) - mx.expand_dims(c, -1) * mx.squeeze(
-        mx.matmul(centroid_P, R.swapaxes(-1, -2)), -2
-    )
+        RH = mx.sum(R * H.swapaxes(-1, -2), axis=(-1, -2))
+        _eps = _DTYPE_EPS.get(P.dtype, 1.1920929e-7)
+        c = RH / mx.maximum(var_P, _eps)
 
-    aligned_P = mx.expand_dims(mx.expand_dims(c, -1), -1) * mx.matmul(
-        P, R.swapaxes(-1, -2)
-    ) + mx.expand_dims(t, -2)
-    diff = aligned_P - Q
-    mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
-    rmsd = mx.sqrt(mse + _eps)
+        t = mx.squeeze(centroid_Q, -2) - mx.expand_dims(c, -1) * mx.squeeze(
+            mx.matmul(centroid_P, R.swapaxes(-1, -2)), -2
+        )
 
-    if orig_dtype in (mx.float16, mx.bfloat16):
-        R = R.astype(orig_dtype)
-        t = t.astype(orig_dtype)
-        c = c.astype(orig_dtype)
-        rmsd = rmsd.astype(orig_dtype)
-    return R, t, c, rmsd
+        aligned_P = mx.expand_dims(mx.expand_dims(c, -1), -1) * mx.matmul(
+            P, R.swapaxes(-1, -2)
+        ) + mx.expand_dims(t, -2)
+        diff = aligned_P - Q
+        mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
+        rmsd = mx.sqrt(mse + _eps)
+
+        if orig_dtype in (mx.float16, mx.bfloat16):
+            R = R.astype(orig_dtype)
+            t = t.astype(orig_dtype)
+            c = c.astype(orig_dtype)
+            rmsd = rmsd.astype(orig_dtype)
+        return R, t, c, rmsd

--- a/src/kabsch_horn/mlx/horn_quat_3d.py
+++ b/src/kabsch_horn/mlx/horn_quat_3d.py
@@ -5,11 +5,16 @@ from ._utils import _DTYPE_EPS, _float64_device_guard, _warn_if_float64
 
 @mx.custom_function
 def safe_eigh_fwd(A: mx.array) -> tuple[mx.array, mx.array]:
+    # Force evaluation so we can inspect for NaN; this breaks lazy fusion and
+    # mx.compile compatibility, but is required to prevent mx.linalg.eigh from
+    # fatally aborting the process on NaN inputs.
     mx.eval(A)
     if mx.any(mx.isnan(A)).item():
+        # Return NaN-filled tensors matching mx.linalg.eigh shapes:
+        # L: [..., n], V: [..., n, n]
         n = A.shape[-1]
         nan_l = mx.full((*A.shape[:-2], n), float("nan"), dtype=A.dtype)
-        nan_v = mx.full_like(A, float("nan"))
+        nan_v = mx.full(A.shape, float("nan"), dtype=A.dtype)
         return nan_l, nan_v
     L, V = mx.linalg.eigh(A, stream=mx.cpu)
     return L, V

--- a/src/kabsch_horn/mlx/kabsch_svd_nd.py
+++ b/src/kabsch_horn/mlx/kabsch_svd_nd.py
@@ -1,6 +1,6 @@
 import mlx.core as mx
 
-from ._utils import _DTYPE_EPS, _warn_if_float64
+from ._utils import _DTYPE_EPS, _float64_device_guard, _warn_if_float64
 
 
 @mx.custom_function
@@ -10,6 +10,14 @@ def safe_svd(A: mx.array) -> tuple[mx.array, mx.array, mx.array]:
     and coincident singular values) robustly for MLX.
     Uses mlx.core.linalg.svd
     """
+    mx.eval(A)
+    if mx.any(mx.isnan(A)).item():
+        M, N = A.shape[-2], A.shape[-1]
+        K = min(M, N)
+        nan_u = mx.full((*A.shape[:-1], M), float("nan"), dtype=A.dtype)
+        nan_s = mx.full((*A.shape[:-2], K), float("nan"), dtype=A.dtype)
+        nan_vt = mx.full((*A.shape[:-2], N, N), float("nan"), dtype=A.dtype)
+        return nan_u, nan_s, nan_vt
     U, S, Vt = mx.linalg.svd(A, stream=mx.cpu)
     return U, S, Vt
 
@@ -45,12 +53,15 @@ def safe_svd_bwd(primals, cotangents, outputs):
     S_sq = mx.square(S)
     S_sq_diff = mx.expand_dims(S_sq, -2) - mx.expand_dims(S_sq, -1)
 
-    # Add epsilon to diagonal before reciprocal
+    # Sign-preserving masking for near-zero off-diagonal differences,
+    # matching the pattern in PyTorch and safe_eigh_bwd.
     eps = _DTYPE_EPS.get(S_sq_diff.dtype, 1.1920929e-7)
     eye = mx.eye(S_sq_diff.shape[-1], dtype=S_sq_diff.dtype)
-    S_sq_diff_safe = mx.where(mx.abs(S_sq_diff) < eps, eye * eps, S_sq_diff)
+    mask = mx.abs(S_sq_diff) < eps
+    safe_diff = mx.where(mask, mx.where(S_sq_diff >= 0, eps, -eps), S_sq_diff)
+    safe_diff = mx.where(eye == 1, mx.ones_like(safe_diff), safe_diff)
 
-    F = 1.0 / S_sq_diff_safe
+    F = 1.0 / safe_diff
     F = mx.where(eye == 1, mx.zeros_like(F), F)
 
     J = F * (Ut_dU - Ut_dU.swapaxes(-1, -2))
@@ -105,83 +116,85 @@ def kabsch(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
     _warn_if_float64(P, Q)
-    orig_dtype = P.dtype
-    if P.dtype != Q.dtype:
-        # Mixed dtypes: promote to higher precision
-        target = mx.float64 if mx.float64 in (P.dtype, Q.dtype) else mx.float32
-        P = P.astype(target)
-        Q = Q.astype(target)
-        orig_dtype = target
-    elif orig_dtype in (mx.float16, mx.bfloat16):
-        P = P.astype(mx.float32)
-        Q = Q.astype(mx.float32)
 
-    centroid_P = mx.mean(P, axis=-2, keepdims=True)
-    centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
+    with _float64_device_guard(P, Q):
+        orig_dtype = P.dtype
+        if P.dtype != Q.dtype:
+            # Mixed dtypes: promote to higher precision
+            target = mx.float64 if mx.float64 in (P.dtype, Q.dtype) else mx.float32
+            P = P.astype(target)
+            Q = Q.astype(target)
+            orig_dtype = target
+        elif orig_dtype in (mx.float16, mx.bfloat16):
+            P = P.astype(mx.float32)
+            Q = Q.astype(mx.float32)
 
-    p = P - centroid_P
-    q = Q - centroid_Q
+        centroid_P = mx.mean(P, axis=-2, keepdims=True)
+        centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
 
-    # mlx doesn't have transpose_b kwarg for all functions, we manually transpose
-    H = mx.matmul(p.swapaxes(-1, -2), q)
+        p = P - centroid_P
+        q = Q - centroid_Q
 
-    U, _S, Vt = safe_svd(H)
+        # mlx doesn't have transpose_b kwarg for all functions, we manually transpose
+        H = mx.matmul(p.swapaxes(-1, -2), q)
 
-    R = mx.matmul(Vt.swapaxes(-1, -2), U.swapaxes(-1, -2))
+        U, _S, Vt = safe_svd(H)
 
-    # MLX does not have det, compute det of 3x3 manually
-    # R is batched 3x3 or just 3x3
-    # A B C
-    # D E F
-    # G H I
-    # Det = A(EI - FH) - B(DI - FG) + C(DH - EG)
-    R00 = R[..., 0, 0]
-    R01 = R[..., 0, 1]
-    R02 = R[..., 0, 2]
-    R10 = R[..., 1, 0]
-    R11 = R[..., 1, 1]
-    R12 = R[..., 1, 2]
-    R20 = R[..., 2, 0]
-    R21 = R[..., 2, 1]
-    R22 = R[..., 2, 2]
+        R = mx.matmul(Vt.swapaxes(-1, -2), U.swapaxes(-1, -2))
 
-    d = (
-        R00 * (R11 * R22 - R12 * R21)
-        - R01 * (R10 * R22 - R12 * R20)
-        + R02 * (R10 * R21 - R11 * R20)
-    )
+        # MLX does not have det, compute det of 3x3 manually
+        # R is batched 3x3 or just 3x3
+        # A B C
+        # D E F
+        # G H I
+        # Det = A(EI - FH) - B(DI - FG) + C(DH - EG)
+        R00 = R[..., 0, 0]
+        R01 = R[..., 0, 1]
+        R02 = R[..., 0, 2]
+        R10 = R[..., 1, 0]
+        R11 = R[..., 1, 1]
+        R12 = R[..., 1, 2]
+        R20 = R[..., 2, 0]
+        R21 = R[..., 2, 1]
+        R22 = R[..., 2, 2]
 
-    # Correction
-    d_sign = mx.where(
-        d < 0, mx.array(-1.0, dtype=P.dtype), mx.array(1.0, dtype=P.dtype)
-    )
+        d = (
+            R00 * (R11 * R22 - R12 * R21)
+            - R01 * (R10 * R22 - R12 * R20)
+            + R02 * (R10 * R21 - R11 * R20)
+        )
 
-    D = P.shape[-1]
-    ones = mx.ones((*P.shape[:-2], D - 1), dtype=P.dtype)
-    diag = mx.concatenate([ones, mx.expand_dims(d_sign, -1)], axis=-1)
+        # Correction
+        d_sign = mx.where(
+            d < 0, mx.array(-1.0, dtype=P.dtype), mx.array(1.0, dtype=P.dtype)
+        )
 
-    # MLX diag only works for 1D. We need to construct batched diag
-    # Best way is broadcasting multiplication using expanded dims
-    I_reflect_V = Vt.swapaxes(-1, -2) * mx.expand_dims(diag, -2)
+        D = P.shape[-1]
+        ones = mx.ones((*P.shape[:-2], D - 1), dtype=P.dtype)
+        diag = mx.concatenate([ones, mx.expand_dims(d_sign, -1)], axis=-1)
 
-    R = mx.matmul(I_reflect_V, U.swapaxes(-1, -2))
+        # MLX diag only works for 1D. We need to construct batched diag
+        # Best way is broadcasting multiplication using expanded dims
+        I_reflect_V = Vt.swapaxes(-1, -2) * mx.expand_dims(diag, -2)
 
-    t = mx.squeeze(centroid_Q, -2) - mx.squeeze(
-        mx.matmul(centroid_P, R.swapaxes(-1, -2)), -2
-    )
+        R = mx.matmul(I_reflect_V, U.swapaxes(-1, -2))
 
-    P_aligned = mx.matmul(P, R.swapaxes(-1, -2)) + mx.expand_dims(t, -2)
-    diff = P_aligned - Q
-    mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
-    _eps = _DTYPE_EPS.get(P.dtype, 1.1920929e-7)
-    rmsd = mx.sqrt(mse + _eps)
+        t = mx.squeeze(centroid_Q, -2) - mx.squeeze(
+            mx.matmul(centroid_P, R.swapaxes(-1, -2)), -2
+        )
 
-    if orig_dtype in (mx.float16, mx.bfloat16):
-        R = R.astype(orig_dtype)
-        t = t.astype(orig_dtype)
-        rmsd = rmsd.astype(orig_dtype)
+        P_aligned = mx.matmul(P, R.swapaxes(-1, -2)) + mx.expand_dims(t, -2)
+        diff = P_aligned - Q
+        mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
+        _eps = _DTYPE_EPS.get(P.dtype, 1.1920929e-7)
+        rmsd = mx.sqrt(mse + _eps)
 
-    return R, t, rmsd
+        if orig_dtype in (mx.float16, mx.bfloat16):
+            R = R.astype(orig_dtype)
+            t = t.astype(orig_dtype)
+            rmsd = rmsd.astype(orig_dtype)
+
+        return R, t, rmsd
 
 
 def kabsch_umeyama(
@@ -230,84 +243,86 @@ def kabsch_umeyama(
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
     _warn_if_float64(P, Q)
-    orig_dtype = P.dtype
-    if P.dtype != Q.dtype:
-        # Mixed dtypes: promote to higher precision
-        target = mx.float64 if mx.float64 in (P.dtype, Q.dtype) else mx.float32
-        P = P.astype(target)
-        Q = Q.astype(target)
-        orig_dtype = target
-    elif orig_dtype in (mx.float16, mx.bfloat16):
-        P = P.astype(mx.float32)
-        Q = Q.astype(mx.float32)
 
-    centroid_P = mx.mean(P, axis=-2, keepdims=True)
-    centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
+    with _float64_device_guard(P, Q):
+        orig_dtype = P.dtype
+        if P.dtype != Q.dtype:
+            # Mixed dtypes: promote to higher precision
+            target = mx.float64 if mx.float64 in (P.dtype, Q.dtype) else mx.float32
+            P = P.astype(target)
+            Q = Q.astype(target)
+            orig_dtype = target
+        elif orig_dtype in (mx.float16, mx.bfloat16):
+            P = P.astype(mx.float32)
+            Q = Q.astype(mx.float32)
 
-    p = P - centroid_P
-    q = Q - centroid_Q
+        centroid_P = mx.mean(P, axis=-2, keepdims=True)
+        centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
 
-    var_P = mx.sum(mx.square(p), axis=(-2, -1)) / P.shape[-2]
-    # Cross-covariance matrix (divided by N for Umeyama scale estimation)
-    H = mx.matmul(p.swapaxes(-1, -2), q) / P.shape[-2]
+        p = P - centroid_P
+        q = Q - centroid_Q
 
-    U, S, Vt = safe_svd(H)
+        var_P = mx.sum(mx.square(p), axis=(-2, -1)) / P.shape[-2]
+        # Cross-covariance matrix (divided by N for Umeyama scale estimation)
+        H = mx.matmul(p.swapaxes(-1, -2), q) / P.shape[-2]
 
-    R = mx.matmul(Vt.swapaxes(-1, -2), U.swapaxes(-1, -2))
+        U, S, Vt = safe_svd(H)
 
-    # Compute det of 3x3 manually
-    R00 = R[..., 0, 0]
-    R01 = R[..., 0, 1]
-    R02 = R[..., 0, 2]
-    R10 = R[..., 1, 0]
-    R11 = R[..., 1, 1]
-    R12 = R[..., 1, 2]
-    R20 = R[..., 2, 0]
-    R21 = R[..., 2, 1]
-    R22 = R[..., 2, 2]
+        R = mx.matmul(Vt.swapaxes(-1, -2), U.swapaxes(-1, -2))
 
-    d = (
-        R00 * (R11 * R22 - R12 * R21)
-        - R01 * (R10 * R22 - R12 * R20)
-        + R02 * (R10 * R21 - R11 * R20)
-    )
-    d_sign = mx.where(
-        d < 0, mx.array(-1.0, dtype=P.dtype), mx.array(1.0, dtype=P.dtype)
-    )
+        # Compute det of 3x3 manually
+        R00 = R[..., 0, 0]
+        R01 = R[..., 0, 1]
+        R02 = R[..., 0, 2]
+        R10 = R[..., 1, 0]
+        R11 = R[..., 1, 1]
+        R12 = R[..., 1, 2]
+        R20 = R[..., 2, 0]
+        R21 = R[..., 2, 1]
+        R22 = R[..., 2, 2]
 
-    D = P.shape[-1]
-    ones = mx.ones((*P.shape[:-2], D - 1), dtype=P.dtype)
-    diag = mx.concatenate([ones, mx.expand_dims(d_sign, -1)], axis=-1)
+        d = (
+            R00 * (R11 * R22 - R12 * R21)
+            - R01 * (R10 * R22 - R12 * R20)
+            + R02 * (R10 * R21 - R11 * R20)
+        )
+        d_sign = mx.where(
+            d < 0, mx.array(-1.0, dtype=P.dtype), mx.array(1.0, dtype=P.dtype)
+        )
 
-    # MLX diag only works for 1D. We need to construct batched diag
-    # Best way is broadcasting multiplication using expanded dims
-    I_reflect_V = Vt.swapaxes(-1, -2) * mx.expand_dims(diag, -2)
+        D = P.shape[-1]
+        ones = mx.ones((*P.shape[:-2], D - 1), dtype=P.dtype)
+        diag = mx.concatenate([ones, mx.expand_dims(d_sign, -1)], axis=-1)
 
-    R = mx.matmul(I_reflect_V, U.swapaxes(-1, -2))
+        # MLX diag only works for 1D. We need to construct batched diag
+        # Best way is broadcasting multiplication using expanded dims
+        I_reflect_V = Vt.swapaxes(-1, -2) * mx.expand_dims(diag, -2)
 
-    S_corr = diag
+        R = mx.matmul(I_reflect_V, U.swapaxes(-1, -2))
 
-    _eps = _DTYPE_EPS.get(P.dtype, 1.1920929e-7)
-    c = mx.sum(S * S_corr, axis=-1) / mx.maximum(var_P, _eps)
+        S_corr = diag
 
-    centroid_P_rot = mx.matmul(centroid_P, R.swapaxes(-1, -2))
-    t = mx.squeeze(centroid_Q, -2) - mx.expand_dims(c, -1) * mx.squeeze(
-        centroid_P_rot, -2
-    )
+        _eps = _DTYPE_EPS.get(P.dtype, 1.1920929e-7)
+        c = mx.sum(S * S_corr, axis=-1) / mx.maximum(var_P, _eps)
 
-    c_exp = mx.expand_dims(mx.expand_dims(c, -1), -1)
-    P_aligned = c_exp * mx.matmul(P, R.swapaxes(-1, -2)) + mx.expand_dims(t, -2)
-    diff = P_aligned - Q
-    mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
-    rmsd = mx.sqrt(mse + _eps)
+        centroid_P_rot = mx.matmul(centroid_P, R.swapaxes(-1, -2))
+        t = mx.squeeze(centroid_Q, -2) - mx.expand_dims(c, -1) * mx.squeeze(
+            centroid_P_rot, -2
+        )
 
-    if orig_dtype in (mx.float16, mx.bfloat16):
-        R = R.astype(orig_dtype)
-        t = t.astype(orig_dtype)
-        c = c.astype(orig_dtype)
-        rmsd = rmsd.astype(orig_dtype)
+        c_exp = mx.expand_dims(mx.expand_dims(c, -1), -1)
+        P_aligned = c_exp * mx.matmul(P, R.swapaxes(-1, -2)) + mx.expand_dims(t, -2)
+        diff = P_aligned - Q
+        mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
+        rmsd = mx.sqrt(mse + _eps)
 
-    return R, t, c, rmsd
+        if orig_dtype in (mx.float16, mx.bfloat16):
+            R = R.astype(orig_dtype)
+            t = t.astype(orig_dtype)
+            c = c.astype(orig_dtype)
+            rmsd = rmsd.astype(orig_dtype)
+
+        return R, t, c, rmsd
 
 
 def kabsch_rmsd(P: mx.array, Q: mx.array) -> mx.array:

--- a/src/kabsch_horn/mlx/kabsch_svd_nd.py
+++ b/src/kabsch_horn/mlx/kabsch_svd_nd.py
@@ -9,9 +9,16 @@ def safe_svd(A: mx.array) -> tuple[mx.array, mx.array, mx.array]:
     Computes SVD with a custom gradient to handle degenerate cases (zero singular values
     and coincident singular values) robustly for MLX.
     Uses mlx.core.linalg.svd
+
+    mx.eval(A) is called before the NaN check because MLX's lazy evaluation means
+    the array may not be materialized yet. Without it, mx.isnan would operate on
+    unevaluated data. This also means safe_svd is incompatible with mx.compile.
     """
+    # Force evaluation so we can inspect values; see docstring for rationale.
     mx.eval(A)
     if mx.any(mx.isnan(A)).item():
+        # Return NaN-filled tensors matching mx.linalg.svd's full SVD shapes:
+        # U: [..., M, M], S: [..., K], Vt: [..., N, N] where K = min(M, N)
         M, N = A.shape[-2], A.shape[-1]
         K = min(M, N)
         nan_u = mx.full((*A.shape[:-1], M), float("nan"), dtype=A.dtype)
@@ -69,11 +76,15 @@ def safe_svd_bwd(primals, cotangents, outputs):
 
     dS_mat = mx.expand_dims(dS, -1) * mx.eye(dS.shape[-1], dtype=dS.dtype)
 
-    # For PyTorch and tf we found term = dS + J@S + S@K or similar.
-    # We will test +/-
+    # SVD backward: dA = U @ (dS_diag + J @ S + S @ K) @ Vt
+    # The + signs here (vs - in PyTorch) are correct because S_sq_diff uses the
+    # opposite axis ordering for expand_dims, producing F with flipped sign.
     term = dS_mat + mx.matmul(J, S_mat) + mx.matmul(S_mat, K)
 
     dA = mx.matmul(U, mx.matmul(term, Vt))
+    # NaN safety net: when inputs trigger the NaN guard, outputs are all-NaN and
+    # the backward receives NaN cotangents. Zero them out to avoid propagating
+    # NaN gradients into the optimizer.
     dA = mx.where(mx.isnan(dA), mx.zeros_like(dA), dA)
 
     return (dA,)

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -449,8 +449,8 @@ try:
 
         @property
         def supports_nan_input(self) -> bool:
-            # MLX linalg.svd fatally aborts the process on NaN inputs
-            return False
+            # NaN inputs are caught before reaching linalg.svd/eigh
+            return True
 
         def convert_in(self, arr: np.ndarray) -> mx.array:
             self._set_device()

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -476,31 +476,24 @@ try:
             return ret
 
         def kabsch(self, P: mx.array, Q: mx.array) -> tuple[mx.array, ...]:
-            self._set_device()
             return kabsch_mlx.kabsch(P, Q)
 
         def kabsch_umeyama(self, P: mx.array, Q: mx.array) -> tuple[mx.array, ...]:
-            self._set_device()
             return kabsch_mlx.kabsch_umeyama(P, Q)
 
         def horn(self, P: mx.array, Q: mx.array) -> tuple[mx.array, ...]:
-            self._set_device()
             return kabsch_mlx.horn(P, Q)
 
         def horn_with_scale(self, P: mx.array, Q: mx.array) -> tuple[mx.array, ...]:
-            self._set_device()
             return kabsch_mlx.horn_with_scale(P, Q)
 
         def kabsch_rmsd(self, P: mx.array, Q: mx.array) -> mx.array:
-            self._set_device()
             return kabsch_mlx.kabsch_rmsd(P, Q)
 
         def kabsch_umeyama_rmsd(self, P: mx.array, Q: mx.array) -> mx.array:
-            self._set_device()
             return kabsch_mlx.kabsch_umeyama_rmsd(P, Q)
 
         def is_nan(self, tensor: mx.array) -> bool:
-            self._set_device()
             return mx.any(mx.isnan(tensor)).item()
 
         def get_grad(
@@ -511,7 +504,6 @@ try:
             seed: int | None = 42,
             wrt: str = "P",
         ) -> np.ndarray:
-            self._set_device()
 
             def loss_fn(P_inner, Q_inner):
                 res = func(P_inner, Q_inner)

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -99,14 +99,12 @@ class TestErrorHandling:
         """
         Contract: NaN inputs must propagate to NaN outputs without raising exceptions.
 
-        PyTorch, JAX, and TensorFlow all propagate NaN through SVD. A framework
-        that raises on NaN input would be a real test failure here.
-        MLX is excluded because its linalg.svd fatally aborts the process on NaN.
+        PyTorch, JAX, TensorFlow, and MLX all propagate NaN through SVD/eigh.
+        NumPy raises LinAlgError on NaN and is excluded via supports_nan_input.
         """
         if not adapter.supports_nan_input:
             pytest.skip(
-                "MLX linalg.svd currently throws a fatal hardware Abort on NaNs "
-                "which aborts pytest."
+                f"{adapter.name} does not support NaN inputs (raises or aborts)."
             )
 
         dim = 3
@@ -124,6 +122,46 @@ class TestErrorHandling:
         func = adapter.get_transform_func(algo)
 
         res = func(P, Q)
+
+        for tensor in res:
+            if isinstance(tensor, float):
+                assert math.isnan(tensor) or adapter.is_nan(tensor), (
+                    "Expected NaN to propagate"
+                )
+            else:
+                assert adapter.is_nan(tensor), "Expected NaN to propagate to output"
+
+    @pytest.mark.parametrize("algo", list(ALGORITHMS_3D_ONLY))
+    @pytest.mark.parametrize("adapter", frameworks)
+    def test_horn_propagates_nans_gracefully(
+        self,
+        adapter: FrameworkAdapter,
+        algo: str,
+    ) -> None:
+        """Horn algorithms should propagate NaN without crashing where supported.
+
+        PyTorch and TensorFlow eigh raises on NaN-containing matrices, so only
+        JAX and MLX (which have NaN guards) are expected to pass.
+        """
+        if not adapter.supports_nan_input:
+            pytest.skip(
+                f"{adapter.name} does not support NaN inputs (raises or aborts)."
+            )
+
+        rng = np.random.default_rng(42)
+        P_np = rng.random((5, 3))
+        Q_np = rng.random((5, 3))
+        P_np[0, 0] = np.nan
+
+        P = adapter.convert_in(P_np)
+        Q = adapter.convert_in(Q_np)
+        func = adapter.get_transform_func(algo)
+
+        try:
+            res = func(P, Q)
+        except Exception:
+            # Some frameworks (PyTorch, TensorFlow) raise on NaN eigh input
+            pytest.skip(f"{adapter.name} eigh raises on NaN input")
 
         for tensor in res:
             if isinstance(tensor, float):
@@ -254,3 +292,43 @@ class TestNumpyFloat32DtypePromotion:
 
         for arr in result:
             assert arr.dtype == np.float32, f"Expected float32 output, got {arr.dtype}"
+
+
+class TestMLXDeviceRestoration:
+    """Verify _float64_device_guard restores the default device."""
+
+    @pytest.mark.parametrize(
+        "algo", ["kabsch", "kabsch_umeyama", "horn", "horn_with_scale"]
+    )
+    def test_device_restored_after_float64_call(self, algo: str) -> None:
+        try:
+            import mlx.core as mx
+
+            from kabsch_horn import mlx as kabsch_mlx
+        except ImportError:
+            pytest.skip("MLX not available")
+
+        # Set a known device before the call
+        mx.set_default_device(mx.gpu)
+        original = mx.default_device()
+
+        rng = np.random.default_rng(0)
+        P = mx.array(rng.random((5, 3)), dtype=mx.float64)
+        Q = mx.array(rng.random((5, 3)), dtype=mx.float64)
+
+        import warnings
+
+        func_map = {
+            "kabsch": kabsch_mlx.kabsch,
+            "kabsch_umeyama": kabsch_mlx.kabsch_umeyama,
+            "horn": kabsch_mlx.horn,
+            "horn_with_scale": kabsch_mlx.horn_with_scale,
+        }
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            func_map[algo](P, Q)
+
+        assert mx.default_device() == original, (
+            f"Expected device {original} after float64 call, got {mx.default_device()}"
+        )


### PR DESCRIPTION
## Summary

- **#152 (critical)**: `safe_svd_bwd` used `eye * eps` replacement which zeroed gradients for coincident singular values. Replaced with sign-preserving masking matching PyTorch and `safe_eigh_bwd`.
- **#154 (moderate)**: `_warn_if_float64` permanently set the global default device to CPU via `mx.set_default_device(mx.cpu)`. Replaced with a `_float64_device_guard` context manager that restores the original device after the call.
- **#155 (moderate)**: NaN inputs to `mx.linalg.svd`/`mx.linalg.eigh` fatally abort the process. Added NaN guards in `safe_svd` and `safe_eigh_fwd` that return NaN-filled tensors with correct shapes.

Closes #152, closes #154, closes #155.

## Test plan

- [x] `uv run ruff check . && uv run ruff format .` -- passes
- [x] `uv run pytest tests/ -k "mlx or MLX"` -- 821 passed, 28 skipped (non-3D dim filters)
- [x] `uv run pytest tests/` -- 4857 passed, 136 skipped, 4 xfailed (1 pre-existing TF Hypothesis flake)
- [x] NaN tests in `test_error_handling.py::test_propagates_nans_gracefully` now run for MLX instead of skipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)