### PR TITLE
fix: clamp scale factor before half-precision downcast

### DIFF
--- a/src/kabsch_horn/jax/horn_quat_3d.py
+++ b/src/kabsch_horn/jax/horn_quat_3d.py
@@ -269,6 +269,7 @@ def horn_with_scale(
         if orig_dtype in (jnp.float16, jnp.bfloat16):
             R = R.astype(orig_dtype)
             t = t.astype(orig_dtype)
+            c = jnp.clip(c, max=jnp.finfo(orig_dtype).max)
             c = c.astype(orig_dtype)
             rmsd = rmsd.astype(orig_dtype)
         return R, t, c, rmsd
@@ -280,6 +281,7 @@ def horn_with_scale(
     if orig_dtype in (jnp.float16, jnp.bfloat16):
         R = R.astype(orig_dtype)
         t = t.astype(orig_dtype)
+        c = jnp.clip(c, max=jnp.finfo(orig_dtype).max)
         c = c.astype(orig_dtype)
         rmsd = rmsd.astype(orig_dtype)
     return R, t, c, rmsd

--- a/src/kabsch_horn/jax/kabsch_svd_nd.py
+++ b/src/kabsch_horn/jax/kabsch_svd_nd.py
@@ -289,6 +289,7 @@ def kabsch_umeyama(
         if orig_dtype in (jnp.float16, jnp.bfloat16):
             R = R.astype(orig_dtype)
             t = t.astype(orig_dtype)
+            c = jnp.clip(c, max=jnp.finfo(orig_dtype).max)
             c = c.astype(orig_dtype)
             rmsd = rmsd.astype(orig_dtype)
 
@@ -302,6 +303,7 @@ def kabsch_umeyama(
     if orig_dtype in (jnp.float16, jnp.bfloat16):
         R = R.astype(orig_dtype)
         t = t.astype(orig_dtype)
+        c = jnp.clip(c, max=jnp.finfo(orig_dtype).max)
         c = c.astype(orig_dtype)
         rmsd = rmsd.astype(orig_dtype)
 

--- a/src/kabsch_horn/mlx/horn_quat_3d.py
+++ b/src/kabsch_horn/mlx/horn_quat_3d.py
@@ -291,6 +291,7 @@ def horn_with_scale(
         if orig_dtype in (mx.float16, mx.bfloat16):
             R = R.astype(orig_dtype)
             t = t.astype(orig_dtype)
+            c = mx.minimum(c, mx.array(mx.finfo(orig_dtype).max, dtype=c.dtype))
             c = c.astype(orig_dtype)
             rmsd = rmsd.astype(orig_dtype)
         return R, t, c, rmsd

--- a/src/kabsch_horn/mlx/kabsch_svd_nd.py
+++ b/src/kabsch_horn/mlx/kabsch_svd_nd.py
@@ -330,6 +330,7 @@ def kabsch_umeyama(
         if orig_dtype in (mx.float16, mx.bfloat16):
             R = R.astype(orig_dtype)
             t = t.astype(orig_dtype)
+            c = mx.minimum(c, mx.array(mx.finfo(orig_dtype).max, dtype=c.dtype))
             c = c.astype(orig_dtype)
             rmsd = rmsd.astype(orig_dtype)
 

--- a/src/kabsch_horn/numpy/horn_quat_3d.py
+++ b/src/kabsch_horn/numpy/horn_quat_3d.py
@@ -241,6 +241,7 @@ def horn_with_scale(
     if orig_dtype in (np.float16,):
         R = R.astype(orig_dtype)
         t = t.astype(orig_dtype)
+        c = np.clip(c, a_min=None, a_max=np.finfo(orig_dtype).max)
         c = c.astype(orig_dtype)
         rmsd = rmsd.astype(orig_dtype)
     return R, t, c, rmsd

--- a/src/kabsch_horn/numpy/kabsch_svd_nd.py
+++ b/src/kabsch_horn/numpy/kabsch_svd_nd.py
@@ -225,6 +225,7 @@ def kabsch_umeyama(
     if orig_dtype in (np.float16,):
         R = R.astype(orig_dtype)
         t = t.astype(orig_dtype)
+        c = np.clip(c, a_min=None, a_max=np.finfo(orig_dtype).max)
         c = c.astype(orig_dtype)
         rmsd = rmsd.astype(orig_dtype)
     return R, t, c, rmsd

--- a/src/kabsch_horn/pytorch/horn_quat_3d.py
+++ b/src/kabsch_horn/pytorch/horn_quat_3d.py
@@ -299,6 +299,7 @@ def horn_with_scale(
         if orig_dtype in (torch.float16, torch.bfloat16):
             R = R.to(orig_dtype)
             t = t.to(orig_dtype)
+            c = torch.clamp(c, max=torch.finfo(orig_dtype).max)
             c = c.to(orig_dtype)
             rmsd = rmsd.to(orig_dtype)
         return R, t, c, rmsd
@@ -310,6 +311,7 @@ def horn_with_scale(
     if orig_dtype in (torch.float16, torch.bfloat16):
         R = R.to(orig_dtype)
         t = t.to(orig_dtype)
+        c = torch.clamp(c, max=torch.finfo(orig_dtype).max)
         c = c.to(orig_dtype)
         rmsd = rmsd.to(orig_dtype)
     return R, t, c, rmsd

--- a/src/kabsch_horn/pytorch/kabsch_svd_nd.py
+++ b/src/kabsch_horn/pytorch/kabsch_svd_nd.py
@@ -340,6 +340,7 @@ def kabsch_umeyama(
         if orig_dtype in (torch.float16, torch.bfloat16):
             R = R.to(orig_dtype)
             t = t.to(orig_dtype)
+            c = torch.clamp(c, max=torch.finfo(orig_dtype).max)
             c = c.to(orig_dtype)
             rmsd = rmsd.to(orig_dtype)
         return R, t, c, rmsd
@@ -352,6 +353,7 @@ def kabsch_umeyama(
     if orig_dtype in (torch.float16, torch.bfloat16):
         R = R.to(orig_dtype)
         t = t.to(orig_dtype)
+        c = torch.clamp(c, max=torch.finfo(orig_dtype).max)
         c = c.to(orig_dtype)
         rmsd = rmsd.to(orig_dtype)
 

--- a/src/kabsch_horn/tensorflow/horn_quat_3d.py
+++ b/src/kabsch_horn/tensorflow/horn_quat_3d.py
@@ -310,6 +310,8 @@ def horn_with_scale(
     if orig_dtype in (tf.float16, tf.bfloat16):
         R = tf.cast(R, orig_dtype)
         t = tf.cast(t, orig_dtype)
+        c_max = tf.constant(tf.dtypes.as_dtype(orig_dtype).max, dtype=c.dtype)
+        c = tf.minimum(c, c_max)
         c = tf.cast(c, orig_dtype)
         rmsd = tf.cast(rmsd, orig_dtype)
     return R, t, c, rmsd

--- a/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
+++ b/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
@@ -285,6 +285,8 @@ def kabsch_umeyama(
     if orig_dtype in (tf.float16, tf.bfloat16):
         R = tf.cast(R, orig_dtype)
         t = tf.cast(t, orig_dtype)
+        c_max = tf.constant(tf.dtypes.as_dtype(orig_dtype).max, dtype=c.dtype)
+        c = tf.minimum(c, c_max)
         c = tf.cast(c, orig_dtype)
         rmsd = tf.cast(rmsd, orig_dtype)
 

--- a/tests/test_differentiability_traps.py
+++ b/tests/test_differentiability_traps.py
@@ -210,8 +210,8 @@ class TestDifferentiabilityTraps:
             adapter, "precision", "float64"
         ) in ("float16", "bfloat16"):
             pytest.skip(
-                "Scale algorithms require division by variance, which overflows "
-                "float16 on origin collapse."
+                "Scale algorithms produce large gradients on origin collapse "
+                "that overflow float16/bfloat16 range."
             )
 
         rng = np.random.default_rng(42)
@@ -306,13 +306,6 @@ class TestDifferentiabilityTraps:
         algo: str,
     ) -> None:
         """Gradients remain finite for near-collinear point clouds (Hypothesis)."""
-        if algo in ALGORITHMS_WITH_SCALE and getattr(
-            adapter, "precision", "float64"
-        ) in ("float16", "bfloat16"):
-            pytest.skip(
-                "Scale algorithms require division by variance, which can overflow "
-                "float16 on near-collinear inputs."
-            )
 
         @settings(
             max_examples=_MAX_EXAMPLES,
@@ -381,12 +374,6 @@ class TestDifferentiabilityTraps:
         algo: str,
     ) -> None:
         """Gradients remain finite for near-coplanar point clouds (Hypothesis)."""
-        if algo in ALGORITHMS_WITH_SCALE and getattr(
-            adapter, "precision", "float64"
-        ) in ("float16", "bfloat16"):
-            pytest.skip(
-                "Umeyama variance division overflows float16 on near-coplanar inputs."
-            )
         if adapter.name == "MLXAdapter" and adapter.precision == "float32":
             pytest.skip(
                 "MLX float32 SafeSVD backward is unstable for near-coplanar inputs"
@@ -450,3 +437,28 @@ class TestDifferentiabilityTraps:
             assert np.all(np.isfinite(grad))
 
         _inner()
+
+    @pytest.mark.parametrize("algo", list(ALGORITHMS_WITH_SCALE))
+    @pytest.mark.parametrize("adapter", frameworks)
+    def test_scale_factor_finite_for_half_precision_origin_collapse(
+        self,
+        adapter: FrameworkAdapter,
+        algo: str,
+        dim: int,
+    ) -> None:
+        """Scale factor c stays finite (not inf) in half-precision origin collapse."""
+        if getattr(adapter, "precision", "float64") not in ("float16", "bfloat16"):
+            pytest.skip("Only relevant for half-precision adapters.")
+
+        rng = np.random.default_rng(42)
+        P_np = np.zeros((5, dim), dtype=np.float64)
+        Q_np = rng.random((5, dim)).astype(np.float64)
+
+        P = adapter.convert_in(P_np)
+        Q = adapter.convert_in(Q_np)
+        func = adapter.get_transform_func(algo)
+
+        res = func(P, Q)
+        c = adapter.convert_out(res[2])
+
+        assert np.all(np.isfinite(c)), f"Scale factor overflowed: {c}"

--- a/tests/test_differentiability_traps.py
+++ b/tests/test_differentiability_traps.py
@@ -440,7 +440,7 @@ class TestDifferentiabilityTraps:
 
     @pytest.mark.parametrize("algo", list(ALGORITHMS_WITH_SCALE))
     @pytest.mark.parametrize("adapter", frameworks)
-    def test_scale_factor_finite_for_half_precision_origin_collapse(
+    def test_scale_factor_finite_float16_origin_collapse(
         self,
         adapter: FrameworkAdapter,
         algo: str,


### PR DESCRIPTION
## Summary

Fixes #160. When `var_P` is near-zero (origin collapse, near-collinear inputs), the scale factor `c` computed in float32 can overflow to `inf` when downcast to float16/bfloat16 (max ~65504).

- Clamp `c` to `finfo(orig_dtype).max` before the downcast in all 10 source files (14 sites across NumPy, PyTorch, JAX, TensorFlow, MLX)
- Remove 2 test skips that are no longer needed (near-collinear and near-coplanar Hypothesis tests with scale + half-precision)
- Add `test_scale_factor_finite_for_half_precision_origin_collapse` verifying `c` stays finite

## Test plan

- [x] `uv run ruff check . && uv run ruff format .` -- passes
- [x] `uv run pytest tests/` (fast mode) -- 4870 passed, 176 skipped
- [x] `uv run pytest tests/test_differentiability_traps.py -k "test_scale_factor_finite" --full` -- 28 passed (all half-precision adapters)
- [x] Previously-skipped near-collinear/near-coplanar hypothesis tests now pass in `--full` mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)