### PR TITLE
fix: reject 1D inputs with ValueError instead of IndexError

### DIFF
--- a/src/kabsch_horn/jax/horn_quat_3d.py
+++ b/src/kabsch_horn/jax/horn_quat_3d.py
@@ -140,6 +140,10 @@ def horn(
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
         )
+    if P.ndim < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
+        )
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")
     if P.shape[-2] < 2:
@@ -216,6 +220,10 @@ def horn_with_scale(
     if P.shape != Q.shape:
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
+        )
+    if P.ndim < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
         )
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")

--- a/src/kabsch_horn/jax/kabsch_svd_nd.py
+++ b/src/kabsch_horn/jax/kabsch_svd_nd.py
@@ -115,6 +115,10 @@ def kabsch(
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
         )
+    if P.ndim < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
+        )
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
 
@@ -220,6 +224,10 @@ def kabsch_umeyama(
     if P.shape != Q.shape:
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
+        )
+    if P.ndim < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
         )
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")

--- a/src/kabsch_horn/mlx/horn_quat_3d.py
+++ b/src/kabsch_horn/mlx/horn_quat_3d.py
@@ -73,6 +73,10 @@ def horn(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
         )
+    if P.ndim < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
+        )
     _warn_if_float64(P, Q)
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")
@@ -191,6 +195,10 @@ def horn_with_scale(
     if P.shape != Q.shape:
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
+        )
+    if P.ndim < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
         )
     _warn_if_float64(P, Q)
     if P.shape[-1] != 3:

--- a/src/kabsch_horn/mlx/kabsch_svd_nd.py
+++ b/src/kabsch_horn/mlx/kabsch_svd_nd.py
@@ -118,6 +118,10 @@ def kabsch(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
         )
+    if P.ndim < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
+        )
 
     if P.shape[-1] != 3:
         raise ValueError(
@@ -244,6 +248,10 @@ def kabsch_umeyama(
     if P.shape != Q.shape:
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
+        )
+    if P.ndim < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
         )
 
     if P.shape[-1] != 3:

--- a/src/kabsch_horn/numpy/horn_quat_3d.py
+++ b/src/kabsch_horn/numpy/horn_quat_3d.py
@@ -78,6 +78,10 @@ def horn(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarr
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
         )
+    if P.ndim < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
+        )
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")
     if P.shape[-2] < 2:
@@ -168,6 +172,10 @@ def horn_with_scale(
     if P.shape != Q.shape:
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
+        )
+    if P.ndim < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
         )
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")

--- a/src/kabsch_horn/numpy/kabsch_svd_nd.py
+++ b/src/kabsch_horn/numpy/kabsch_svd_nd.py
@@ -23,6 +23,10 @@ def kabsch(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.nda
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
         )
+    if P.ndim < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
+        )
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
 
@@ -135,6 +139,10 @@ def kabsch_umeyama(
     if P.shape != Q.shape:
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
+        )
+    if P.ndim < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
         )
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")

--- a/src/kabsch_horn/pytorch/horn_quat_3d.py
+++ b/src/kabsch_horn/pytorch/horn_quat_3d.py
@@ -63,6 +63,10 @@ def horn(
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
         )
+    if P.ndim < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
+        )
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")
     if P.shape[-2] < 2:
@@ -191,6 +195,10 @@ def horn_with_scale(
     if P.shape != Q.shape:
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
+        )
+    if P.ndim < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
         )
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")

--- a/src/kabsch_horn/pytorch/kabsch_svd_nd.py
+++ b/src/kabsch_horn/pytorch/kabsch_svd_nd.py
@@ -140,6 +140,10 @@ def kabsch(
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
         )
+    if P.ndim < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
+        )
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
 
@@ -259,6 +263,10 @@ def kabsch_umeyama(
     if P.shape != Q.shape:
         raise ValueError(
             f"P and Q must have the same shape, got {P.shape} vs {Q.shape}"
+        )
+    if P.ndim < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
         )
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")

--- a/src/kabsch_horn/tensorflow/horn_quat_3d.py
+++ b/src/kabsch_horn/tensorflow/horn_quat_3d.py
@@ -66,6 +66,13 @@ def horn(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
     tf.debugging.assert_equal(
         tf.shape(P), tf.shape(Q), message="P and Q must have the same shape"
     )
+    if P.shape.rank is not None and P.shape.rank < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
+        )
+    tf.debugging.assert_rank_at_least(
+        P, 2, message="Input must be at least 2D with shape [..., N, D]"
+    )
     if P.shape[-1] is not None and P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")
     tf.debugging.assert_equal(
@@ -199,6 +206,13 @@ def horn_with_scale(
         )
     tf.debugging.assert_equal(
         tf.shape(P), tf.shape(Q), message="P and Q must have the same shape"
+    )
+    if P.shape.rank is not None and P.shape.rank < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
+        )
+    tf.debugging.assert_rank_at_least(
+        P, 2, message="Input must be at least 2D with shape [..., N, D]"
     )
     if P.shape[-1] is not None and P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")

--- a/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
+++ b/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
@@ -95,6 +95,13 @@ def kabsch(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]
     tf.debugging.assert_equal(
         tf.shape(P), tf.shape(Q), message="P and Q must have the same shape"
     )
+    if P.shape.rank is not None and P.shape.rank < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
+        )
+    tf.debugging.assert_rank_at_least(
+        P, 2, message="Input must be at least 2D with shape [..., N, D]"
+    )
     if P.shape[-2] is not None and P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
     tf.debugging.assert_greater_equal(
@@ -202,6 +209,13 @@ def kabsch_umeyama(
         )
     tf.debugging.assert_equal(
         tf.shape(P), tf.shape(Q), message="P and Q must have the same shape"
+    )
+    if P.shape.rank is not None and P.shape.rank < 2:
+        raise ValueError(
+            f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
+        )
+    tf.debugging.assert_rank_at_least(
+        P, 2, message="Input must be at least 2D with shape [..., N, D]"
     )
     if P.shape[-2] is not None and P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -201,7 +201,7 @@ class TestRejects1DInput:
         Q = adapter.convert_in(Q_np)
         func = adapter.get_transform_func(algo)
 
-        with pytest.raises((ValueError, Exception), match=r"2D"):
+        with pytest.raises(ValueError, match=r"at least 2D"):
             func(P, Q)
 
 

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -186,6 +186,25 @@ class TestErrorHandling:
             func(P, Q)
 
 
+class TestRejects1DInput:
+    """1D array inputs must raise ValueError, not IndexError."""
+
+    @pytest.mark.parametrize("algo", ALGORITHMS)
+    @pytest.mark.parametrize("adapter", frameworks)
+    def test_1d_input_raises_value_error(
+        self, adapter: FrameworkAdapter, algo: str
+    ) -> None:
+        P_np = np.array([1.0, 2.0, 3.0])
+        Q_np = np.array([4.0, 5.0, 6.0])
+
+        P = adapter.convert_in(P_np)
+        Q = adapter.convert_in(Q_np)
+        func = adapter.get_transform_func(algo)
+
+        with pytest.raises((ValueError, Exception), match=r"2D"):
+            func(P, Q)
+
+
 class TestNumpySinglePointRejection:
     """NumPy N=1 inputs must raise ValueError for all algorithms."""
 


### PR DESCRIPTION
## Summary
- Adds `ndim < 2` / `rank < 2` guard as the first dimensional validation in all 18 public functions across NumPy, PyTorch, JAX, TensorFlow, and MLX
- 1D inputs now raise `ValueError` with the actual shape instead of an opaque `IndexError: tuple index out of range`
- TensorFlow functions also get a dynamic `tf.debugging.assert_rank_at_least` for graph-mode coverage

Closes #153

## Test plan
- [x] New `TestRejects1DInput` class in `test_error_handling.py` -- parametrized across all 4 algorithms and all framework adapters
- [x] All existing tests pass (`uv run pytest tests/`)
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)