### PR TITLE
docs: annotate backward-pass sign conventions per framework

### DIFF
--- a/src/kabsch_horn/jax/kabsch_svd_nd.py
+++ b/src/kabsch_horn/jax/kabsch_svd_nd.py
@@ -54,10 +54,25 @@ def _bwd(res, g):
 
     grad_Vh = mH(grad_V)
 
+    # SVD backward-pass sign convention (JAX)
+    # ------------------------------------
+    # jnp.linalg.svd returns (U, S, Vh) with A = U @ diag(S) @ Vh.
+    #
+    # The F matrix is F_ij = 1 / (S_i^2 - S_j^2), computed as:
+    #   D = S_sq[..., newaxis] - S_sq[..., newaxis, :]   (row - col)
+    #
+    # With this ordering, the gradient formula is:
+    #   dA = U @ (diag(dS) - J @ S - S @ K) @ Vh
+    #
+    # TensorFlow and MLX use the transposed axis ordering for D
+    # (col - row), which negates F and flips the formula to +J, +K.
+    # Both forms are equivalent -- see Townsend (2016),
+    # "Differentiating the Singular Value Decomposition".
+
     # 1. Square of S
     S_sq = jnp.square(S)  # BxD
 
-    # 2. D = S_sq - S_sq^T
+    # 2. D = S_i^2 - S_j^2 (row - col)
     D = S_sq[..., jnp.newaxis] - S_sq[..., jnp.newaxis, :]  # BxDxD
 
     # 3. Safe F

--- a/src/kabsch_horn/mlx/kabsch_svd_nd.py
+++ b/src/kabsch_horn/mlx/kabsch_svd_nd.py
@@ -57,11 +57,24 @@ def safe_svd_bwd(primals, cotangents, outputs):
     dV = dVt.swapaxes(-1, -2)
     Vt_dV = mx.matmul(Vt, dV)
 
+    # SVD backward-pass sign convention (MLX)
+    # -------------------------------------
+    # mx.linalg.svd returns (U, S, Vt) with A = U @ diag(S) @ Vt.
+    #
+    # The F matrix is F_ij = 1 / (S_j^2 - S_i^2), computed as:
+    #   S_sq_diff = expand_dims(-2) - expand_dims(-1)   (col - row)
+    #
+    # This is the transposed axis ordering relative to PyTorch/JAX,
+    # which negates F. To compensate, the gradient formula uses + signs:
+    #   dA = U @ (diag(dS) + J @ S + S @ K) @ Vt
+    #
+    # Both forms are equivalent -- see Townsend (2016),
+    # "Differentiating the Singular Value Decomposition".
+
     S_sq = mx.square(S)
     S_sq_diff = mx.expand_dims(S_sq, -2) - mx.expand_dims(S_sq, -1)
 
-    # Sign-preserving masking for near-zero off-diagonal differences,
-    # matching the pattern in PyTorch and safe_eigh_bwd.
+    # Sign-preserving masking for near-zero off-diagonal differences.
     eps = _DTYPE_EPS.get(S_sq_diff.dtype, 1.1920929e-7)
     eye = mx.eye(S_sq_diff.shape[-1], dtype=S_sq_diff.dtype)
     mask = mx.abs(S_sq_diff) < eps
@@ -76,9 +89,6 @@ def safe_svd_bwd(primals, cotangents, outputs):
 
     dS_mat = mx.expand_dims(dS, -1) * mx.eye(dS.shape[-1], dtype=dS.dtype)
 
-    # SVD backward: dA = U @ (dS_diag + J @ S + S @ K) @ Vt
-    # The + signs here (vs - in PyTorch) are correct because S_sq_diff uses the
-    # opposite axis ordering for expand_dims, producing F with flipped sign.
     term = dS_mat + mx.matmul(J, S_mat) + mx.matmul(S_mat, K)
 
     dA = mx.matmul(U, mx.matmul(term, Vt))

--- a/src/kabsch_horn/pytorch/kabsch_svd_nd.py
+++ b/src/kabsch_horn/pytorch/kabsch_svd_nd.py
@@ -46,9 +46,20 @@ class SafeSVD(torch.autograd.Function):
         U, S, Vh = ctx.saved_tensors
         eps = torch.finfo(S.dtype).eps
 
-        # Backward pass of SVD for real matrices:
-        # A = U S V^T
-        # dA = U (diag(dS) - J S - S K) V^T
+        # SVD backward-pass sign convention (PyTorch)
+        # ----------------------------------------
+        # torch.linalg.svd returns (U, S, Vh) with A = U @ diag(S) @ Vh.
+        #
+        # The F matrix is F_ij = 1 / (S_i^2 - S_j^2), computed as:
+        #   D = S_sq.unsqueeze(-1) - S_sq.unsqueeze(-2)   (row - col)
+        #
+        # With this ordering, the gradient formula is:
+        #   dA = U @ (diag(dS) - J @ S - S @ K) @ Vh
+        #
+        # TensorFlow and MLX use the transposed axis ordering for D
+        # (col - row), which negates F and flips the formula to +J, +K.
+        # Both forms are equivalent -- see Townsend (2016),
+        # "Differentiating the Singular Value Decomposition".
 
         # Replace None gradients with zeros
         grad_U = torch.zeros_like(U) if grad_U is None else grad_U

--- a/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
+++ b/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
@@ -27,6 +27,21 @@ def safe_svd(A: tf.Tensor) -> tuple[tf.Tensor, ...]:
         else:
             dS_mat = tf.zeros_like(S_mat)
 
+        # SVD backward-pass sign convention (TensorFlow)
+        # ---------------------------------------------
+        # tf.linalg.svd returns (S, U, V) with A = U @ diag(S) @ V^T.
+        # Note: TF returns V, not Vh -- so V^T is the right factor.
+        #
+        # The F matrix is F_ij = 1 / (S_j^2 - S_i^2), computed as:
+        #   S_sq_diff = expand_dims(-2) - expand_dims(-1)   (col - row)
+        #
+        # This is the transposed axis ordering relative to PyTorch/JAX,
+        # which negates F. To compensate, the gradient formula uses + signs:
+        #   dA = U @ (diag(dS) + J @ S + S @ K) @ V^T
+        #
+        # Both forms are equivalent -- see Townsend (2016),
+        # "Differentiating the Singular Value Decomposition".
+
         # Create F matrix: F_ij = 1 / (S_j^2 - S_i^2)
         S_sq = tf.square(S)
         S_sq_diff = tf.expand_dims(S_sq, -2) - tf.expand_dims(S_sq, -1)


### PR DESCRIPTION
## Summary

- Adds a comment block to each framework's `safe_svd` backward pass explaining the SVD return convention, how the F-matrix axis ordering determines the sign of J/K terms in the gradient formula, and a reference to Townsend (2016)
- Consolidates the existing ad-hoc comment in MLX into the new standard block and removes the redundant inline note

Closes #157

## Test plan

- [x] `uv run ruff check . && uv run ruff format .` passes
- [x] `uv run pytest tests/` passes (4938 passed, 176 skipped)
- [x] Verify comment accuracy by inspecting each framework's `expand_dims` / `unsqueeze` axis ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)