### PR TITLE
feat: add optional per-point weights to all alignment functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ R, t, c, rmsd = kh.horn_with_scale(P_3d, Q_3d)
 # Single-call RMSD loss (autodiff frameworks only; gradients remain stable)
 loss = kh.kabsch_rmsd(P_nd, Q_nd)
 loss.mean().backward()
+
+# Per-point weights (e.g., confidence scores, B-factors)
+weights = torch.rand(10, 100)  # shape: [Batch, Points]
+R, t, rmsd = kh.kabsch(P_nd, Q_nd, weights=weights)
 ```
 
 ## Framework Support

--- a/src/kabsch_horn/jax/horn_quat_3d.py
+++ b/src/kabsch_horn/jax/horn_quat_3d.py
@@ -57,7 +57,7 @@ safe_eigh.defvjp(_eigh_fwd, _eigh_bwd)
 
 
 def _horn_core(
-    P: jnp.ndarray, Q: jnp.ndarray
+    P: jnp.ndarray, Q: jnp.ndarray, weights: jnp.ndarray | None = None
 ) -> tuple[
     jnp.ndarray,
     jnp.ndarray,
@@ -69,14 +69,28 @@ def _horn_core(
     """Core Horn computation on batched [B, N, 3] float32 arrays.
 
     Returns (R, p, q, centroid_P, centroid_Q, H) where q = centered Q points
-    and H = p.T @ q (unscaled).
+    and H = (w*p).T @ q (weighted, unscaled) or p.T @ q (unweighted, unscaled).
     """
-    centroid_P = jnp.mean(P, axis=1, keepdims=True)
-    centroid_Q = jnp.mean(Q, axis=1, keepdims=True)
+    if weights is not None:
+        w = weights[:, :, jnp.newaxis]  # BxNx1
+        w_sum = jnp.sum(weights, axis=-1)  # B
+        centroid_P = (
+            jnp.sum(w * P, axis=1, keepdims=True) / w_sum[:, jnp.newaxis, jnp.newaxis]
+        )
+        centroid_Q = (
+            jnp.sum(w * Q, axis=1, keepdims=True) / w_sum[:, jnp.newaxis, jnp.newaxis]
+        )
+    else:
+        centroid_P = jnp.mean(P, axis=1, keepdims=True)
+        centroid_Q = jnp.mean(Q, axis=1, keepdims=True)
+
     p = P - centroid_P
     q = Q - centroid_Q
 
-    H = jnp.matmul(jnp.swapaxes(p, 1, 2), q)  # [B, 3, 3], unscaled
+    if weights is not None:
+        H = jnp.matmul(jnp.swapaxes(w * p, 1, 2), q)  # [B, 3, 3], weighted unscaled
+    else:
+        H = jnp.matmul(jnp.swapaxes(p, 1, 2), q)  # [B, 3, 3], unscaled
 
     S = H + jnp.swapaxes(H, 1, 2)
     tr = jnp.trace(H, axis1=1, axis2=2)
@@ -119,7 +133,7 @@ def _horn_core(
 
 
 def horn(
-    P: jnp.ndarray, Q: jnp.ndarray
+    P: jnp.ndarray, Q: jnp.ndarray, weights: jnp.ndarray | None = None
 ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
     """
     Computes optimal rotation and translation to align P to Q using Horn's
@@ -131,6 +145,8 @@ def horn(
     Args:
         P: Source points, shape [..., N, 3].
         Q: Target points, shape [..., N, 3].
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, rmsd): Rotation [..., 3, 3], translation [..., 3], and RMSD [...].
@@ -148,6 +164,18 @@ def horn(
         raise ValueError("Horn's method is strictly for 3D point clouds")
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
+
+    if weights is not None:
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match "
+                f"P.shape[:-1] {P.shape[:-1]}"
+            )
+        if jnp.any(weights < 0):
+            raise ValueError("weights must be non-negative")
+        if not jnp.all(jnp.sum(weights, axis=-1) > 0):
+            raise ValueError("weights must sum to a positive value")
+
     orig_dtype = P.dtype
     if P.dtype != Q.dtype:
         # Mixed dtypes: promote to higher precision
@@ -159,18 +187,25 @@ def horn(
         P = P.astype(jnp.float32)
         Q = Q.astype(jnp.float32)
 
+    if weights is not None:
+        weights = weights.astype(P.dtype)
+
     is_single = P.ndim == 2
     if is_single:
         P = P[jnp.newaxis, ...]
         Q = Q[jnp.newaxis, ...]
+        if weights is not None:
+            weights = weights[jnp.newaxis, :]
 
     orig_shape = P.shape
     N_pts = orig_shape[-2]
     batch_dims = orig_shape[:-2]
     P = P.reshape(-1, N_pts, 3)
     Q = Q.reshape(-1, N_pts, 3)
+    if weights is not None:
+        weights = weights.reshape(-1, N_pts)
 
-    R, p, q, centroid_P, centroid_Q, _H = _horn_core(P, Q)
+    R, p, q, centroid_P, centroid_Q, _H = _horn_core(P, Q, weights)
 
     t = jnp.squeeze(centroid_Q, axis=1) - jnp.squeeze(
         jnp.matmul(centroid_P, jnp.swapaxes(R, 1, 2)), axis=1
@@ -178,7 +213,12 @@ def horn(
 
     aligned = jnp.matmul(p, jnp.swapaxes(R, 1, 2))
     _eps = jnp.finfo(P.dtype).eps
-    mse = jnp.sum(jnp.square(aligned - q), axis=(1, 2)) / N_pts
+    if weights is not None:
+        w_sum = jnp.sum(weights, axis=-1)  # B
+        residual_sq = jnp.sum(jnp.square(aligned - q), axis=-1)  # BxN
+        mse = jnp.sum(weights * residual_sq, axis=-1) / w_sum  # B
+    else:
+        mse = jnp.sum(jnp.square(aligned - q), axis=(1, 2)) / N_pts
     rmsd = jnp.sqrt(mse + _eps)
 
     if is_single:
@@ -200,7 +240,7 @@ def horn(
 
 
 def horn_with_scale(
-    P: jnp.ndarray, Q: jnp.ndarray
+    P: jnp.ndarray, Q: jnp.ndarray, weights: jnp.ndarray | None = None
 ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
     """
     Computes optimal rotation, translation, and scale to align P to Q
@@ -211,6 +251,8 @@ def horn_with_scale(
     Args:
         P: Source points, shape [..., N, 3].
         Q: Target points, shape [..., N, 3].
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, c, rmsd): Rotation [..., 3, 3], translation [..., 3],
@@ -229,6 +271,18 @@ def horn_with_scale(
         raise ValueError("Horn's method is strictly for 3D point clouds")
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
+
+    if weights is not None:
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match "
+                f"P.shape[:-1] {P.shape[:-1]}"
+            )
+        if jnp.any(weights < 0):
+            raise ValueError("weights must be non-negative")
+        if not jnp.all(jnp.sum(weights, axis=-1) > 0):
+            raise ValueError("weights must sum to a positive value")
+
     orig_dtype = P.dtype
     if P.dtype != Q.dtype:
         # Mixed dtypes: promote to higher precision
@@ -240,25 +294,40 @@ def horn_with_scale(
         P = P.astype(jnp.float32)
         Q = Q.astype(jnp.float32)
 
+    if weights is not None:
+        weights = weights.astype(P.dtype)
+
     is_single = P.ndim == 2
     if is_single:
         P = P[jnp.newaxis, ...]
         Q = Q[jnp.newaxis, ...]
+        if weights is not None:
+            weights = weights[jnp.newaxis, :]
 
     orig_shape = P.shape
     N_pts = orig_shape[-2]
     batch_dims = orig_shape[:-2]
     P = P.reshape(-1, N_pts, 3)
     Q = Q.reshape(-1, N_pts, 3)
+    if weights is not None:
+        weights = weights.reshape(-1, N_pts)
 
-    R, p, _q, centroid_P, centroid_Q, H = _horn_core(P, Q)
+    R, p, _q, centroid_P, centroid_Q, H = _horn_core(P, Q, weights)
 
-    # H is unscaled (p.T @ q); var_P * N_pts = sum(sq(p)), so c = tr(R^T H) / sum(sq(p))
-    var_P = jnp.sum(jnp.square(p), axis=(1, 2)) / N_pts
+    # H is unscaled (weighted or not); compute scale
     _eps = jnp.finfo(P.dtype).eps
-    c = jnp.sum(R * jnp.swapaxes(H, 1, 2), axis=(1, 2)) / (
-        jnp.clip(var_P, min=_eps) * N_pts
-    )
+    if weights is not None:
+        w_sum = jnp.sum(weights, axis=-1)  # B
+        var_P = jnp.sum(weights * jnp.sum(jnp.square(p), axis=-1), axis=-1) / w_sum
+        # c = trace(R^T @ H) / (var_P * w_sum)
+        c = jnp.sum(R * jnp.swapaxes(H, 1, 2), axis=(1, 2)) / (
+            jnp.clip(var_P, min=_eps) * w_sum
+        )
+    else:
+        var_P = jnp.sum(jnp.square(p), axis=(1, 2)) / N_pts
+        c = jnp.sum(R * jnp.swapaxes(H, 1, 2), axis=(1, 2)) / (
+            jnp.clip(var_P, min=_eps) * N_pts
+        )
 
     t = jnp.squeeze(centroid_Q, axis=1) - c[:, jnp.newaxis] * jnp.squeeze(
         jnp.matmul(centroid_P, jnp.swapaxes(R, 1, 2)), axis=1
@@ -269,7 +338,11 @@ def horn_with_scale(
         + t[:, jnp.newaxis, :]
     )
     diff = aligned_P - Q
-    mse = jnp.sum(jnp.square(diff), axis=(1, 2)) / N_pts
+    if weights is not None:
+        residual_sq = jnp.sum(jnp.square(diff), axis=-1)  # BxN
+        mse = jnp.sum(weights * residual_sq, axis=-1) / w_sum  # B
+    else:
+        mse = jnp.sum(jnp.square(diff), axis=(1, 2)) / N_pts
     rmsd = jnp.sqrt(mse + _eps)
 
     if is_single:

--- a/src/kabsch_horn/jax/kabsch_svd_nd.py
+++ b/src/kabsch_horn/jax/kabsch_svd_nd.py
@@ -105,7 +105,7 @@ safe_svd.defvjp(_fwd, _bwd)
 
 
 def kabsch(
-    P: jnp.ndarray, Q: jnp.ndarray
+    P: jnp.ndarray, Q: jnp.ndarray, weights: jnp.ndarray | None = None
 ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
     """
     Computes the optimal rotation and translation to align P to Q using
@@ -114,6 +114,8 @@ def kabsch(
     Args:
         P: Source points, shape [..., N, D].
         Q: Target points, shape [..., N, D].
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, rmsd): Rotation [..., D, D], translation [..., D], and RMSD [...].
@@ -137,6 +139,17 @@ def kabsch(
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
 
+    if weights is not None:
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match "
+                f"P.shape[:-1] {P.shape[:-1]}"
+            )
+        if jnp.any(weights < 0):
+            raise ValueError("weights must be non-negative")
+        if not jnp.all(jnp.sum(weights, axis=-1) > 0):
+            raise ValueError("weights must sum to a positive value")
+
     orig_dtype = P.dtype
     if P.dtype != Q.dtype:
         # Mixed dtypes: promote to higher precision
@@ -148,10 +161,15 @@ def kabsch(
         P = P.astype(jnp.float32)
         Q = Q.astype(jnp.float32)
 
+    if weights is not None:
+        weights = weights.astype(P.dtype)
+
     is_single = P.ndim == 2
     if is_single:
         P = P[jnp.newaxis, ...]
         Q = Q[jnp.newaxis, ...]
+        if weights is not None:
+            weights = weights[jnp.newaxis, :]
 
     orig_shape = P.shape
     D = orig_shape[-1]
@@ -160,14 +178,29 @@ def kabsch(
 
     P = P.reshape(-1, N, D)
     Q = Q.reshape(-1, N, D)
+    if weights is not None:
+        weights = weights.reshape(-1, N)
 
-    centroid_P = jnp.mean(P, axis=1, keepdims=True)
-    centroid_Q = jnp.mean(Q, axis=1, keepdims=True)
+    if weights is not None:
+        w = weights[:, :, jnp.newaxis]  # BxNx1
+        w_sum = jnp.sum(weights, axis=-1)  # B
+        centroid_P = (
+            jnp.sum(w * P, axis=1, keepdims=True) / w_sum[:, jnp.newaxis, jnp.newaxis]
+        )
+        centroid_Q = (
+            jnp.sum(w * Q, axis=1, keepdims=True) / w_sum[:, jnp.newaxis, jnp.newaxis]
+        )
+    else:
+        centroid_P = jnp.mean(P, axis=1, keepdims=True)
+        centroid_Q = jnp.mean(Q, axis=1, keepdims=True)
 
     p = P - centroid_P
     q = Q - centroid_Q
 
-    H = jnp.matmul(jnp.swapaxes(p, 1, 2), q)
+    if weights is not None:
+        H = jnp.matmul(jnp.swapaxes(w * p, 1, 2), q)
+    else:
+        H = jnp.matmul(jnp.swapaxes(p, 1, 2), q)
 
     U, _S, V = safe_svd(H)
 
@@ -186,7 +219,11 @@ def kabsch(
     )
 
     aligned = jnp.matmul(P, jnp.swapaxes(R, 1, 2)) + t[:, jnp.newaxis, :]
-    mse = jnp.sum(jnp.square(aligned - Q), axis=(1, 2)) / N
+    if weights is not None:
+        residual_sq = jnp.sum(jnp.square(aligned - Q), axis=-1)  # BxN
+        mse = jnp.sum(weights * residual_sq, axis=-1) / w_sum  # B
+    else:
+        mse = jnp.sum(jnp.square(aligned - Q), axis=(1, 2)) / N
     rmsd = jnp.sqrt(mse + _eps)
 
     if is_single:
@@ -210,7 +247,7 @@ def kabsch(
 
 
 def kabsch_umeyama(
-    P: jnp.ndarray, Q: jnp.ndarray
+    P: jnp.ndarray, Q: jnp.ndarray, weights: jnp.ndarray | None = None
 ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
     """
     Computes the optimal rotation, translation, and scale to align P to Q
@@ -219,6 +256,8 @@ def kabsch_umeyama(
     Args:
         P: Source points, shape [..., N, D].
         Q: Target points, shape [..., N, D].
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, c, rmsd): Rotation [..., D, D], translation [..., D],
@@ -247,6 +286,17 @@ def kabsch_umeyama(
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
 
+    if weights is not None:
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match "
+                f"P.shape[:-1] {P.shape[:-1]}"
+            )
+        if jnp.any(weights < 0):
+            raise ValueError("weights must be non-negative")
+        if not jnp.all(jnp.sum(weights, axis=-1) > 0):
+            raise ValueError("weights must sum to a positive value")
+
     orig_dtype = P.dtype
     if P.dtype != Q.dtype:
         # Mixed dtypes: promote to higher precision
@@ -258,10 +308,15 @@ def kabsch_umeyama(
         P = P.astype(jnp.float32)
         Q = Q.astype(jnp.float32)
 
+    if weights is not None:
+        weights = weights.astype(P.dtype)
+
     is_single = P.ndim == 2
     if is_single:
         P = P[jnp.newaxis, ...]
         Q = Q[jnp.newaxis, ...]
+        if weights is not None:
+            weights = weights[jnp.newaxis, :]
 
     orig_shape = P.shape
     D = orig_shape[-1]
@@ -270,17 +325,35 @@ def kabsch_umeyama(
 
     P = P.reshape(-1, N, D)
     Q = Q.reshape(-1, N, D)
+    if weights is not None:
+        weights = weights.reshape(-1, N)
 
-    centroid_P = jnp.mean(P, axis=1, keepdims=True)
-    centroid_Q = jnp.mean(Q, axis=1, keepdims=True)
+    if weights is not None:
+        w = weights[:, :, jnp.newaxis]  # BxNx1
+        w_sum = jnp.sum(weights, axis=-1)  # B
+        centroid_P = (
+            jnp.sum(w * P, axis=1, keepdims=True) / w_sum[:, jnp.newaxis, jnp.newaxis]
+        )
+        centroid_Q = (
+            jnp.sum(w * Q, axis=1, keepdims=True) / w_sum[:, jnp.newaxis, jnp.newaxis]
+        )
+    else:
+        centroid_P = jnp.mean(P, axis=1, keepdims=True)
+        centroid_Q = jnp.mean(Q, axis=1, keepdims=True)
 
     p = P - centroid_P
     q = Q - centroid_Q
 
-    # Cross-covariance matrix (divided by N for Umeyama scale estimation)
-    H = jnp.matmul(jnp.swapaxes(p, 1, 2), q) / N
-
-    var_P = jnp.sum(jnp.square(p), axis=(1, 2)) / N
+    # Cross-covariance matrix (divided by N or w_sum for Umeyama scale estimation)
+    if weights is not None:
+        H = (
+            jnp.matmul(jnp.swapaxes(w * p, 1, 2), q)
+            / w_sum[:, jnp.newaxis, jnp.newaxis]
+        )
+        var_P = jnp.sum(weights * jnp.sum(jnp.square(p), axis=-1), axis=-1) / w_sum
+    else:
+        H = jnp.matmul(jnp.swapaxes(p, 1, 2), q) / N
+        var_P = jnp.sum(jnp.square(p), axis=(1, 2)) / N
 
     U, S, V = safe_svd(H)
 
@@ -304,7 +377,11 @@ def kabsch_umeyama(
         c[:, jnp.newaxis, jnp.newaxis] * jnp.matmul(P, jnp.swapaxes(R, 1, 2))
         + t[:, jnp.newaxis, :]
     )
-    mse = jnp.sum(jnp.square(aligned_P - Q), axis=(1, 2)) / N
+    if weights is not None:
+        residual_sq = jnp.sum(jnp.square(aligned_P - Q), axis=-1)  # BxN
+        mse = jnp.sum(weights * residual_sq, axis=-1) / w_sum  # B
+    else:
+        mse = jnp.sum(jnp.square(aligned_P - Q), axis=(1, 2)) / N
     rmsd = jnp.sqrt(mse + _eps)
 
     if is_single:
@@ -333,13 +410,17 @@ def kabsch_umeyama(
     return R, t, c, rmsd
 
 
-def kabsch_rmsd(P: jnp.ndarray, Q: jnp.ndarray) -> jnp.ndarray:
+def kabsch_rmsd(
+    P: jnp.ndarray, Q: jnp.ndarray, weights: jnp.ndarray | None = None
+) -> jnp.ndarray:
     """Computes RMSD after Kabsch alignment. Gradient-safe training loss."""
-    _R, _t, rmsd = kabsch(P, Q)
+    _R, _t, rmsd = kabsch(P, Q, weights=weights)
     return rmsd
 
 
-def kabsch_umeyama_rmsd(P: jnp.ndarray, Q: jnp.ndarray) -> jnp.ndarray:
+def kabsch_umeyama_rmsd(
+    P: jnp.ndarray, Q: jnp.ndarray, weights: jnp.ndarray | None = None
+) -> jnp.ndarray:
     """Computes RMSD after Kabsch-Umeyama alignment. Gradient-safe training loss."""
-    _R, _t, _c, rmsd = kabsch_umeyama(P, Q)
+    _R, _t, _c, rmsd = kabsch_umeyama(P, Q, weights=weights)
     return rmsd

--- a/src/kabsch_horn/mlx/horn_quat_3d.py
+++ b/src/kabsch_horn/mlx/horn_quat_3d.py
@@ -66,7 +66,8 @@ def horn(
     Args:
         P: Source points as mx.array, shape [..., N, 3].
         Q: Target points as mx.array, shape [..., N, 3].
-        weights: Per-point weights, shape [..., N]. If None, uniform weights are used.
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, rmsd): Rotation [..., 3, 3], translation [..., 3], and RMSD [...].
@@ -219,7 +220,8 @@ def horn_with_scale(
     Args:
         P: Source points as mx.array, shape [..., N, 3].
         Q: Target points as mx.array, shape [..., N, 3].
-        weights: Per-point weights, shape [..., N]. If None, uniform weights are used.
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, c, rmsd): Rotation [..., 3, 3], translation [..., 3],

--- a/src/kabsch_horn/mlx/horn_quat_3d.py
+++ b/src/kabsch_horn/mlx/horn_quat_3d.py
@@ -53,7 +53,9 @@ def safe_eigh_bwd(primals, cotangents, outputs):
     return (dA,)
 
 
-def horn(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
+def horn(
+    P: mx.array, Q: mx.array, weights: mx.array | None = None
+) -> tuple[mx.array, mx.array, mx.array]:
     """
     Computes optimal rotation and translation to align P to Q using Horn's
     quaternion method.
@@ -64,6 +66,7 @@ def horn(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
     Args:
         P: Source points as mx.array, shape [..., N, 3].
         Q: Target points as mx.array, shape [..., N, 3].
+        weights: Per-point weights, shape [..., N]. If None, uniform weights are used.
 
     Returns:
         (R, t, rmsd): Rotation [..., 3, 3], translation [..., 3], and RMSD [...].
@@ -77,6 +80,19 @@ def horn(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
         raise ValueError(
             f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
         )
+
+    if weights is not None:
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match "
+                f"P.shape[:-1] {P.shape[:-1]}"
+            )
+        mx.eval(weights)
+        if mx.any(weights < 0).item():
+            raise ValueError("weights must be non-negative")
+        if not mx.all(mx.sum(weights, axis=-1) > 0).item():
+            raise ValueError("weights must sum to a positive value")
+
     _warn_if_float64(P, Q)
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")
@@ -95,13 +111,26 @@ def horn(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
             P = P.astype(mx.float32)
             Q = Q.astype(mx.float32)
 
-        centroid_P = mx.mean(P, axis=-2, keepdims=True)
-        centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
+        if weights is not None:
+            weights = weights.astype(P.dtype)
+
+        if weights is not None:
+            w = mx.expand_dims(weights, -1)  # [..., N, 1]
+            w_sum = mx.sum(weights, axis=-1)  # [...]
+            w_sum_exp = mx.expand_dims(mx.expand_dims(w_sum, -1), -1)  # [..., 1, 1]
+            centroid_P = mx.sum(w * P, axis=-2, keepdims=True) / w_sum_exp
+            centroid_Q = mx.sum(w * Q, axis=-2, keepdims=True) / w_sum_exp
+        else:
+            centroid_P = mx.mean(P, axis=-2, keepdims=True)
+            centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
 
         p = P - centroid_P
         q = Q - centroid_Q
 
-        H = mx.matmul(p.swapaxes(-1, -2), q)
+        if weights is not None:
+            H = mx.matmul((w * p).swapaxes(-1, -2), q)
+        else:
+            H = mx.matmul(p.swapaxes(-1, -2), q)
 
         S = H + H.swapaxes(-1, -2)
         tr = H[..., 0, 0] + H[..., 1, 1] + H[..., 2, 2]
@@ -163,7 +192,11 @@ def horn(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
         aligned = mx.matmul(p, R.swapaxes(-1, -2))
 
         diff = aligned - q
-        mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
+        if weights is not None:
+            residual_sq = mx.sum(mx.square(diff), axis=-1)
+            mse = mx.sum(weights * residual_sq, axis=-1) / w_sum
+        else:
+            mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
         _eps = _DTYPE_EPS.get(P.dtype, 1.1920929e-7)
         rmsd = mx.sqrt(mse + _eps)
 
@@ -175,7 +208,7 @@ def horn(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
 
 
 def horn_with_scale(
-    P: mx.array, Q: mx.array
+    P: mx.array, Q: mx.array, weights: mx.array | None = None
 ) -> tuple[mx.array, mx.array, mx.array, mx.array]:
     """
     Computes optimal rotation, translation, and scale to align P to Q
@@ -186,6 +219,7 @@ def horn_with_scale(
     Args:
         P: Source points as mx.array, shape [..., N, 3].
         Q: Target points as mx.array, shape [..., N, 3].
+        weights: Per-point weights, shape [..., N]. If None, uniform weights are used.
 
     Returns:
         (R, t, c, rmsd): Rotation [..., 3, 3], translation [..., 3],
@@ -200,6 +234,19 @@ def horn_with_scale(
         raise ValueError(
             f"Input must be at least 2D with shape [..., N, D], got shape {P.shape}"
         )
+
+    if weights is not None:
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match "
+                f"P.shape[:-1] {P.shape[:-1]}"
+            )
+        mx.eval(weights)
+        if mx.any(weights < 0).item():
+            raise ValueError("weights must be non-negative")
+        if not mx.all(mx.sum(weights, axis=-1) > 0).item():
+            raise ValueError("weights must sum to a positive value")
+
     _warn_if_float64(P, Q)
     if P.shape[-1] != 3:
         raise ValueError("Horn's method is strictly for 3D point clouds")
@@ -218,15 +265,28 @@ def horn_with_scale(
             P = P.astype(mx.float32)
             Q = Q.astype(mx.float32)
 
-        centroid_P = mx.mean(P, axis=-2, keepdims=True)
-        centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
+        if weights is not None:
+            weights = weights.astype(P.dtype)
+
+        if weights is not None:
+            w = mx.expand_dims(weights, -1)  # [..., N, 1]
+            w_sum = mx.sum(weights, axis=-1)  # [...]
+            w_sum_exp = mx.expand_dims(mx.expand_dims(w_sum, -1), -1)  # [..., 1, 1]
+            centroid_P = mx.sum(w * P, axis=-2, keepdims=True) / w_sum_exp
+            centroid_Q = mx.sum(w * Q, axis=-2, keepdims=True) / w_sum_exp
+        else:
+            centroid_P = mx.mean(P, axis=-2, keepdims=True)
+            centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
 
         p = P - centroid_P
         q = Q - centroid_Q
 
-        var_P = mx.sum(mx.square(p), axis=(-2, -1)) / P.shape[-2]
-
-        H = mx.matmul(p.swapaxes(-1, -2), q) / P.shape[-2]
+        if weights is not None:
+            var_P = mx.sum(weights * mx.sum(mx.square(p), axis=-1), axis=-1) / w_sum
+            H = mx.matmul((w * p).swapaxes(-1, -2), q) / w_sum_exp
+        else:
+            var_P = mx.sum(mx.square(p), axis=(-2, -1)) / P.shape[-2]
+            H = mx.matmul(p.swapaxes(-1, -2), q) / P.shape[-2]
 
         S = H + H.swapaxes(-1, -2)
         tr = H[..., 0, 0] + H[..., 1, 1] + H[..., 2, 2]
@@ -293,7 +353,11 @@ def horn_with_scale(
             P, R.swapaxes(-1, -2)
         ) + mx.expand_dims(t, -2)
         diff = aligned_P - Q
-        mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
+        if weights is not None:
+            residual_sq = mx.sum(mx.square(diff), axis=-1)
+            mse = mx.sum(weights * residual_sq, axis=-1) / w_sum
+        else:
+            mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
         rmsd = mx.sqrt(mse + _eps)
 
         if orig_dtype in (mx.float16, mx.bfloat16):

--- a/src/kabsch_horn/mlx/kabsch_svd_nd.py
+++ b/src/kabsch_horn/mlx/kabsch_svd_nd.py
@@ -100,7 +100,9 @@ def safe_svd_bwd(primals, cotangents, outputs):
     return (dA,)
 
 
-def kabsch(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
+def kabsch(
+    P: mx.array, Q: mx.array, weights: mx.array | None = None
+) -> tuple[mx.array, mx.array, mx.array]:
     """
     Computes the optimal rotation and translation to align P to Q.
 
@@ -109,6 +111,7 @@ def kabsch(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
     Args:
         P: Source points, shape [..., N, 3].
         Q: Target points, shape [..., N, 3].
+        weights: Per-point weights, shape [..., N]. If None, uniform weights are used.
 
     Returns:
         (R, t, rmsd): Rotation [..., 3, 3], translation [..., 3], and RMSD [...].
@@ -140,6 +143,19 @@ def kabsch(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
         )
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
+
+    if weights is not None:
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match "
+                f"P.shape[:-1] {P.shape[:-1]}"
+            )
+        mx.eval(weights)
+        if mx.any(weights < 0).item():
+            raise ValueError("weights must be non-negative")
+        if not mx.all(mx.sum(weights, axis=-1) > 0).item():
+            raise ValueError("weights must sum to a positive value")
+
     _warn_if_float64(P, Q)
 
     with _float64_device_guard(P, Q):
@@ -154,14 +170,27 @@ def kabsch(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
             P = P.astype(mx.float32)
             Q = Q.astype(mx.float32)
 
-        centroid_P = mx.mean(P, axis=-2, keepdims=True)
-        centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
+        if weights is not None:
+            weights = weights.astype(P.dtype)
+
+        if weights is not None:
+            w = mx.expand_dims(weights, -1)  # [..., N, 1]
+            w_sum = mx.sum(weights, axis=-1)  # [...]
+            w_sum_exp = mx.expand_dims(mx.expand_dims(w_sum, -1), -1)  # [..., 1, 1]
+            centroid_P = mx.sum(w * P, axis=-2, keepdims=True) / w_sum_exp
+            centroid_Q = mx.sum(w * Q, axis=-2, keepdims=True) / w_sum_exp
+        else:
+            centroid_P = mx.mean(P, axis=-2, keepdims=True)
+            centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
 
         p = P - centroid_P
         q = Q - centroid_Q
 
         # mlx doesn't have transpose_b kwarg for all functions, we manually transpose
-        H = mx.matmul(p.swapaxes(-1, -2), q)
+        if weights is not None:
+            H = mx.matmul((w * p).swapaxes(-1, -2), q)
+        else:
+            H = mx.matmul(p.swapaxes(-1, -2), q)
 
         U, _S, Vt = safe_svd(H)
 
@@ -210,7 +239,11 @@ def kabsch(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
 
         P_aligned = mx.matmul(P, R.swapaxes(-1, -2)) + mx.expand_dims(t, -2)
         diff = P_aligned - Q
-        mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
+        if weights is not None:
+            residual_sq = mx.sum(mx.square(diff), axis=-1)
+            mse = mx.sum(weights * residual_sq, axis=-1) / w_sum
+        else:
+            mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
         _eps = _DTYPE_EPS.get(P.dtype, 1.1920929e-7)
         rmsd = mx.sqrt(mse + _eps)
 
@@ -223,7 +256,7 @@ def kabsch(P: mx.array, Q: mx.array) -> tuple[mx.array, mx.array, mx.array]:
 
 
 def kabsch_umeyama(
-    P: mx.array, Q: mx.array
+    P: mx.array, Q: mx.array, weights: mx.array | None = None
 ) -> tuple[mx.array, mx.array, mx.array, mx.array]:
     """
     Computes the optimal rotation, translation, and scale to align P to Q
@@ -235,6 +268,7 @@ def kabsch_umeyama(
     Args:
         P: Source points, shape [..., N, 3].
         Q: Target points, shape [..., N, 3].
+        weights: Per-point weights, shape [..., N]. If None, uniform weights are used.
 
     Returns:
         (R, t, c, rmsd): Rotation [..., 3, 3], translation [..., 3],
@@ -271,6 +305,19 @@ def kabsch_umeyama(
         )
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
+
+    if weights is not None:
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match "
+                f"P.shape[:-1] {P.shape[:-1]}"
+            )
+        mx.eval(weights)
+        if mx.any(weights < 0).item():
+            raise ValueError("weights must be non-negative")
+        if not mx.all(mx.sum(weights, axis=-1) > 0).item():
+            raise ValueError("weights must sum to a positive value")
+
     _warn_if_float64(P, Q)
 
     with _float64_device_guard(P, Q):
@@ -285,15 +332,30 @@ def kabsch_umeyama(
             P = P.astype(mx.float32)
             Q = Q.astype(mx.float32)
 
-        centroid_P = mx.mean(P, axis=-2, keepdims=True)
-        centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
+        if weights is not None:
+            weights = weights.astype(P.dtype)
+
+        if weights is not None:
+            w = mx.expand_dims(weights, -1)  # [..., N, 1]
+            w_sum = mx.sum(weights, axis=-1)  # [...]
+            w_sum_exp = mx.expand_dims(mx.expand_dims(w_sum, -1), -1)  # [..., 1, 1]
+            centroid_P = mx.sum(w * P, axis=-2, keepdims=True) / w_sum_exp
+            centroid_Q = mx.sum(w * Q, axis=-2, keepdims=True) / w_sum_exp
+        else:
+            centroid_P = mx.mean(P, axis=-2, keepdims=True)
+            centroid_Q = mx.mean(Q, axis=-2, keepdims=True)
 
         p = P - centroid_P
         q = Q - centroid_Q
 
-        var_P = mx.sum(mx.square(p), axis=(-2, -1)) / P.shape[-2]
-        # Cross-covariance matrix (divided by N for Umeyama scale estimation)
-        H = mx.matmul(p.swapaxes(-1, -2), q) / P.shape[-2]
+        if weights is not None:
+            var_P = mx.sum(weights * mx.sum(mx.square(p), axis=-1), axis=-1) / w_sum
+            # Cross-covariance matrix (divided by w_sum for Umeyama scale estimation)
+            H = mx.matmul((w * p).swapaxes(-1, -2), q) / w_sum_exp
+        else:
+            var_P = mx.sum(mx.square(p), axis=(-2, -1)) / P.shape[-2]
+            # Cross-covariance matrix (divided by N for Umeyama scale estimation)
+            H = mx.matmul(p.swapaxes(-1, -2), q) / P.shape[-2]
 
         U, S, Vt = safe_svd(H)
 
@@ -342,7 +404,11 @@ def kabsch_umeyama(
         c_exp = mx.expand_dims(mx.expand_dims(c, -1), -1)
         P_aligned = c_exp * mx.matmul(P, R.swapaxes(-1, -2)) + mx.expand_dims(t, -2)
         diff = P_aligned - Q
-        mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
+        if weights is not None:
+            residual_sq = mx.sum(mx.square(diff), axis=-1)
+            mse = mx.sum(weights * residual_sq, axis=-1) / w_sum
+        else:
+            mse = mx.mean(mx.sum(mx.square(diff), axis=-1), axis=-1)
         rmsd = mx.sqrt(mse + _eps)
 
         if orig_dtype in (mx.float16, mx.bfloat16):
@@ -355,13 +421,15 @@ def kabsch_umeyama(
         return R, t, c, rmsd
 
 
-def kabsch_rmsd(P: mx.array, Q: mx.array) -> mx.array:
+def kabsch_rmsd(P: mx.array, Q: mx.array, weights: mx.array | None = None) -> mx.array:
     """Computes RMSD after Kabsch alignment. Gradient-safe training loss."""
-    _R, _t, rmsd = kabsch(P, Q)
+    _R, _t, rmsd = kabsch(P, Q, weights=weights)
     return rmsd
 
 
-def kabsch_umeyama_rmsd(P: mx.array, Q: mx.array) -> mx.array:
+def kabsch_umeyama_rmsd(
+    P: mx.array, Q: mx.array, weights: mx.array | None = None
+) -> mx.array:
     """Computes RMSD after Kabsch-Umeyama alignment. Gradient-safe training loss."""
-    _R, _t, _c, rmsd = kabsch_umeyama(P, Q)
+    _R, _t, _c, rmsd = kabsch_umeyama(P, Q, weights=weights)
     return rmsd

--- a/src/kabsch_horn/mlx/kabsch_svd_nd.py
+++ b/src/kabsch_horn/mlx/kabsch_svd_nd.py
@@ -111,7 +111,8 @@ def kabsch(
     Args:
         P: Source points, shape [..., N, 3].
         Q: Target points, shape [..., N, 3].
-        weights: Per-point weights, shape [..., N]. If None, uniform weights are used.
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, rmsd): Rotation [..., 3, 3], translation [..., 3], and RMSD [...].
@@ -268,7 +269,8 @@ def kabsch_umeyama(
     Args:
         P: Source points, shape [..., N, 3].
         Q: Target points, shape [..., N, 3].
-        weights: Per-point weights, shape [..., N]. If None, uniform weights are used.
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, c, rmsd): Rotation [..., 3, 3], translation [..., 3],

--- a/src/kabsch_horn/numpy/horn_quat_3d.py
+++ b/src/kabsch_horn/numpy/horn_quat_3d.py
@@ -60,7 +60,9 @@ def _quat_to_rotation(q_opt: np.ndarray) -> np.ndarray:
     )
 
 
-def horn(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+def horn(
+    P: np.ndarray, Q: np.ndarray, weights: np.ndarray | None = None
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Computes optimal rotation and translation to align P to Q using Horn's
     quaternion method.
@@ -70,6 +72,8 @@ def horn(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarr
     Args:
         P: Source points, shape [..., N, 3].
         Q: Target points, shape [..., N, 3].
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, rmsd): Rotation [..., 3, 3], translation [..., 3], and RMSD [...].
@@ -87,6 +91,18 @@ def horn(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarr
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
 
+    if weights is not None:
+        weights = np.asarray(weights)
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match "
+                f"P.shape[:-1] {P.shape[:-1]}"
+            )
+        if np.any(weights < 0):
+            raise ValueError("weights must be non-negative")
+        if not np.all(np.sum(weights, axis=-1) > 0):
+            raise ValueError("weights must sum to a positive value")
+
     orig_dtype = P.dtype
     if P.dtype != Q.dtype:
         # Mixed dtypes: promote to higher precision
@@ -98,10 +114,15 @@ def horn(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarr
         P = P.astype(np.float32)
         Q = Q.astype(np.float32)
 
+    if weights is not None:
+        weights = weights.astype(P.dtype)
+
     is_single = P.ndim == 2
     if is_single:
         P = P[np.newaxis, ...]
         Q = Q[np.newaxis, ...]
+        if weights is not None:
+            weights = weights[np.newaxis, :]
 
     orig_shape = P.shape
     batch_dims = orig_shape[:-2]
@@ -109,14 +130,29 @@ def horn(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarr
 
     P = np.reshape(P, (-1, N, D))
     Q = np.reshape(Q, (-1, N, D))
+    if weights is not None:
+        weights = np.reshape(weights, (-1, N))
 
-    centroid_P = np.mean(P, axis=1, keepdims=True)
-    centroid_Q = np.mean(Q, axis=1, keepdims=True)
+    if weights is not None:
+        w = weights[:, :, np.newaxis]  # BxNx1
+        w_sum = np.sum(weights, axis=-1)  # B
+        centroid_P = (
+            np.sum(w * P, axis=1, keepdims=True) / w_sum[:, np.newaxis, np.newaxis]
+        )
+        centroid_Q = (
+            np.sum(w * Q, axis=1, keepdims=True) / w_sum[:, np.newaxis, np.newaxis]
+        )
+    else:
+        centroid_P = np.mean(P, axis=1, keepdims=True)
+        centroid_Q = np.mean(Q, axis=1, keepdims=True)
 
     p = P - centroid_P
     q = Q - centroid_Q
 
-    H = np.matmul(p.transpose(0, 2, 1), q)
+    if weights is not None:
+        H = np.matmul((w * p).transpose(0, 2, 1), q)
+    else:
+        H = np.matmul(p.transpose(0, 2, 1), q)
 
     N_mat = _build_horn_matrix(H)
 
@@ -131,13 +167,12 @@ def horn(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarr
     )
 
     aligned = np.matmul(p, R.transpose(0, 2, 1))
-    rmsd = np.sqrt(
-        np.clip(
-            np.sum(np.square(aligned - q), axis=(1, 2)) / N,
-            a_min=0.0,
-            a_max=None,
-        )
-    )
+    if weights is not None:
+        residual_sq = np.sum(np.square(aligned - q), axis=-1)  # BxN
+        mse = np.sum(weights * residual_sq, axis=-1) / w_sum  # B
+    else:
+        mse = np.sum(np.square(aligned - q), axis=(1, 2)) / N
+    rmsd = np.sqrt(np.clip(mse, a_min=0.0, a_max=None))
 
     if is_single:
         R, t, rmsd = R[0], t[0], rmsd[0]
@@ -153,7 +188,7 @@ def horn(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarr
 
 
 def horn_with_scale(
-    P: np.ndarray, Q: np.ndarray
+    P: np.ndarray, Q: np.ndarray, weights: np.ndarray | None = None
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
     Computes optimal rotation, translation, and scale to align P to Q
@@ -164,6 +199,8 @@ def horn_with_scale(
     Args:
         P: Source points, shape [..., N, 3].
         Q: Target points, shape [..., N, 3].
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, c, rmsd): Rotation [..., 3, 3], translation [..., 3],
@@ -182,6 +219,18 @@ def horn_with_scale(
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
 
+    if weights is not None:
+        weights = np.asarray(weights)
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match "
+                f"P.shape[:-1] {P.shape[:-1]}"
+            )
+        if np.any(weights < 0):
+            raise ValueError("weights must be non-negative")
+        if not np.all(np.sum(weights, axis=-1) > 0):
+            raise ValueError("weights must sum to a positive value")
+
     orig_dtype = P.dtype
     if P.dtype != Q.dtype:
         # Mixed dtypes: promote to higher precision
@@ -193,10 +242,15 @@ def horn_with_scale(
         P = P.astype(np.float32)
         Q = Q.astype(np.float32)
 
+    if weights is not None:
+        weights = weights.astype(P.dtype)
+
     is_single = P.ndim == 2
     if is_single:
         P = P[np.newaxis, ...]
         Q = Q[np.newaxis, ...]
+        if weights is not None:
+            weights = weights[np.newaxis, :]
 
     orig_shape = P.shape
     batch_dims = orig_shape[:-2]
@@ -204,16 +258,31 @@ def horn_with_scale(
 
     P = np.reshape(P, (-1, N, D))
     Q = np.reshape(Q, (-1, N, D))
+    if weights is not None:
+        weights = np.reshape(weights, (-1, N))
 
-    centroid_P = np.mean(P, axis=1, keepdims=True)
-    centroid_Q = np.mean(Q, axis=1, keepdims=True)
+    if weights is not None:
+        w = weights[:, :, np.newaxis]  # BxNx1
+        w_sum = np.sum(weights, axis=-1)  # B
+        centroid_P = (
+            np.sum(w * P, axis=1, keepdims=True) / w_sum[:, np.newaxis, np.newaxis]
+        )
+        centroid_Q = (
+            np.sum(w * Q, axis=1, keepdims=True) / w_sum[:, np.newaxis, np.newaxis]
+        )
+    else:
+        centroid_P = np.mean(P, axis=1, keepdims=True)
+        centroid_Q = np.mean(Q, axis=1, keepdims=True)
 
     p = P - centroid_P
     q = Q - centroid_Q
 
-    var_P = np.sum(np.square(p), axis=(1, 2)) / N
-
-    H = np.matmul(p.transpose(0, 2, 1), q) / N
+    if weights is not None:
+        var_P = np.sum(weights * np.sum(np.square(p), axis=-1), axis=-1) / w_sum  # B
+        H = np.matmul((w * p).transpose(0, 2, 1), q) / w_sum[:, np.newaxis, np.newaxis]
+    else:
+        var_P = np.sum(np.square(p), axis=(1, 2)) / N
+        H = np.matmul(p.transpose(0, 2, 1), q) / N
 
     N_mat = _build_horn_matrix(H)
 
@@ -235,9 +304,12 @@ def horn_with_scale(
         + t[:, np.newaxis, :]
     )
     diff = aligned_P - Q
-    rmsd = np.sqrt(
-        np.clip(np.sum(np.square(diff), axis=(1, 2)) / N, a_min=0.0, a_max=None)
-    )
+    if weights is not None:
+        residual_sq = np.sum(np.square(diff), axis=-1)  # BxN
+        mse = np.sum(weights * residual_sq, axis=-1) / w_sum  # B
+    else:
+        mse = np.sum(np.square(diff), axis=(1, 2)) / N
+    rmsd = np.sqrt(np.clip(mse, a_min=0.0, a_max=None))
 
     if is_single:
         R, t, c, rmsd = R[0], t[0], c[0], rmsd[0]

--- a/src/kabsch_horn/numpy/kabsch_svd_nd.py
+++ b/src/kabsch_horn/numpy/kabsch_svd_nd.py
@@ -1,13 +1,17 @@
 import numpy as np
 
 
-def kabsch(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+def kabsch(
+    P: np.ndarray, Q: np.ndarray, weights: np.ndarray | None = None
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Computes the optimal rotation and translation to align P to Q.
 
     Args:
         P: Source points, shape [..., N, D].
         Q: Target points, shape [..., N, D].
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, rmsd): Rotation [..., D, D], translation [..., D], RMSD [...].
@@ -30,6 +34,18 @@ def kabsch(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.nda
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
 
+    if weights is not None:
+        weights = np.asarray(weights)
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match "
+                f"P.shape[:-1] {P.shape[:-1]}"
+            )
+        if np.any(weights < 0):
+            raise ValueError("weights must be non-negative")
+        if not np.all(np.sum(weights, axis=-1) > 0):
+            raise ValueError("weights must sum to a positive value")
+
     orig_dtype = P.dtype
     if P.dtype != Q.dtype:
         # Mixed dtypes: promote to higher precision
@@ -41,11 +57,16 @@ def kabsch(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.nda
         P = P.astype(np.float32)
         Q = Q.astype(np.float32)
 
+    if weights is not None:
+        weights = weights.astype(P.dtype)
+
     # Auto-batch single elements
     is_single = P.ndim == 2
     if is_single:
         P = P[np.newaxis, ...]
         Q = Q[np.newaxis, ...]
+        if weights is not None:
+            weights = weights[np.newaxis, :]
 
     orig_shape = P.shape
     batch_dims = orig_shape[:-2]
@@ -53,17 +74,32 @@ def kabsch(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.nda
 
     P = np.reshape(P, (-1, N, D))
     Q = np.reshape(Q, (-1, N, D))
+    if weights is not None:
+        weights = np.reshape(weights, (-1, N))
 
     # Compute centroids
-    centroid_P = np.mean(P, axis=1, keepdims=True)  # Bx1xD
-    centroid_Q = np.mean(Q, axis=1, keepdims=True)  # Bx1xD
+    if weights is not None:
+        w = weights[:, :, np.newaxis]  # BxNx1
+        w_sum = np.sum(weights, axis=-1)  # B
+        centroid_P = (
+            np.sum(w * P, axis=1, keepdims=True) / w_sum[:, np.newaxis, np.newaxis]
+        )
+        centroid_Q = (
+            np.sum(w * Q, axis=1, keepdims=True) / w_sum[:, np.newaxis, np.newaxis]
+        )
+    else:
+        centroid_P = np.mean(P, axis=1, keepdims=True)  # Bx1xD
+        centroid_Q = np.mean(Q, axis=1, keepdims=True)  # Bx1xD
 
     # Center the points
     p = P - centroid_P  # BxNxD
     q = Q - centroid_Q  # BxNxD
 
     # Compute the covariance matrix
-    H = np.matmul(p.transpose(0, 2, 1), q)  # BxDxD
+    if weights is not None:
+        H = np.matmul((w * p).transpose(0, 2, 1), q)  # BxDxD
+    else:
+        H = np.matmul(p.transpose(0, 2, 1), q)  # BxDxD
 
     # SVD
     U, _, Vt = np.linalg.svd(H)  # BxDxD
@@ -89,13 +125,12 @@ def kabsch(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.nda
 
     # RMSD
     aligned_P = np.matmul(P, R.transpose(0, 2, 1)) + t[:, np.newaxis, :]
-    rmsd = np.sqrt(
-        np.clip(
-            np.sum(np.square(aligned_P - Q), axis=(1, 2)) / N,
-            a_min=0.0,
-            a_max=None,
-        )
-    )
+    if weights is not None:
+        residual_sq = np.sum(np.square(aligned_P - Q), axis=-1)  # BxN
+        mse = np.sum(weights * residual_sq, axis=-1) / w_sum  # B
+    else:
+        mse = np.sum(np.square(aligned_P - Q), axis=(1, 2)) / N
+    rmsd = np.sqrt(np.clip(mse, a_min=0.0, a_max=None))
 
     if is_single:
         R, t, rmsd = R[0], t[0], rmsd[0]
@@ -111,7 +146,7 @@ def kabsch(P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.nda
 
 
 def kabsch_umeyama(
-    P: np.ndarray, Q: np.ndarray
+    P: np.ndarray, Q: np.ndarray, weights: np.ndarray | None = None
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
     Computes the optimal rotation, translation, and scale to align P to Q
@@ -120,6 +155,8 @@ def kabsch_umeyama(
     Args:
         P: Source points, shape [..., N, D].
         Q: Target points, shape [..., N, D].
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, c, rmsd): Rotation [..., D, D], translation [..., D], scale [...],
@@ -147,6 +184,18 @@ def kabsch_umeyama(
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
 
+    if weights is not None:
+        weights = np.asarray(weights)
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match "
+                f"P.shape[:-1] {P.shape[:-1]}"
+            )
+        if np.any(weights < 0):
+            raise ValueError("weights must be non-negative")
+        if not np.all(np.sum(weights, axis=-1) > 0):
+            raise ValueError("weights must sum to a positive value")
+
     orig_dtype = P.dtype
     if P.dtype != Q.dtype:
         # Mixed dtypes: promote to higher precision
@@ -158,10 +207,15 @@ def kabsch_umeyama(
         P = P.astype(np.float32)
         Q = Q.astype(np.float32)
 
+    if weights is not None:
+        weights = weights.astype(P.dtype)
+
     is_single = P.ndim == 2
     if is_single:
         P = P[np.newaxis, ...]
         Q = Q[np.newaxis, ...]
+        if weights is not None:
+            weights = weights[np.newaxis, :]
 
     orig_shape = P.shape
     batch_dims = orig_shape[:-2]
@@ -169,20 +223,34 @@ def kabsch_umeyama(
 
     P = np.reshape(P, (-1, N, D))
     Q = np.reshape(Q, (-1, N, D))
+    if weights is not None:
+        weights = np.reshape(weights, (-1, N))
 
     # Compute centroids
-    centroid_P = np.mean(P, axis=1, keepdims=True)  # Bx1xD
-    centroid_Q = np.mean(Q, axis=1, keepdims=True)  # Bx1xD
+    if weights is not None:
+        w = weights[:, :, np.newaxis]  # BxNx1
+        w_sum = np.sum(weights, axis=-1)  # B
+        centroid_P = (
+            np.sum(w * P, axis=1, keepdims=True) / w_sum[:, np.newaxis, np.newaxis]
+        )
+        centroid_Q = (
+            np.sum(w * Q, axis=1, keepdims=True) / w_sum[:, np.newaxis, np.newaxis]
+        )
+    else:
+        centroid_P = np.mean(P, axis=1, keepdims=True)  # Bx1xD
+        centroid_Q = np.mean(Q, axis=1, keepdims=True)  # Bx1xD
 
     # Center the points
     p = P - centroid_P  # BxNxD
     q = Q - centroid_Q  # BxNxD
 
-    # Cross-covariance matrix (divided by N for Umeyama scale estimation)
-    H = np.matmul(p.transpose(0, 2, 1), q) / N  # BxDxD
-
-    # Variances
-    var_P = np.sum(np.square(p), axis=(1, 2)) / N  # B
+    # Cross-covariance matrix (divided by N or w_sum for Umeyama scale estimation)
+    if weights is not None:
+        H = np.matmul((w * p).transpose(0, 2, 1), q) / w_sum[:, np.newaxis, np.newaxis]
+        var_P = np.sum(weights * np.sum(np.square(p), axis=-1), axis=-1) / w_sum  # B
+    else:
+        H = np.matmul(p.transpose(0, 2, 1), q) / N  # BxDxD
+        var_P = np.sum(np.square(p), axis=(1, 2)) / N  # B
 
     # SVD
     U, S, Vt = np.linalg.svd(H)  # BxDxD, BxD, BxDxD
@@ -215,13 +283,12 @@ def kabsch_umeyama(
         c[:, np.newaxis, np.newaxis] * np.matmul(P, R.transpose(0, 2, 1))
         + t[:, np.newaxis, :]
     )
-    rmsd = np.sqrt(
-        np.clip(
-            np.sum(np.square(aligned_P - Q), axis=(1, 2)) / N,
-            a_min=0.0,
-            a_max=None,
-        )
-    )
+    if weights is not None:
+        residual_sq = np.sum(np.square(aligned_P - Q), axis=-1)  # BxN
+        mse = np.sum(weights * residual_sq, axis=-1) / w_sum  # B
+    else:
+        mse = np.sum(np.square(aligned_P - Q), axis=(1, 2)) / N
+    rmsd = np.sqrt(np.clip(mse, a_min=0.0, a_max=None))
 
     if is_single:
         R, t, c, rmsd = R[0], t[0], c[0], rmsd[0]

--- a/src/kabsch_horn/pytorch/horn_quat_3d.py
+++ b/src/kabsch_horn/pytorch/horn_quat_3d.py
@@ -53,7 +53,7 @@ class SafeEigh(torch.autograd.Function):
 
 
 def horn(
-    P: torch.Tensor, Q: torch.Tensor
+    P: torch.Tensor, Q: torch.Tensor, weights: torch.Tensor | None = None
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Computes optimal rotation and translation to align P to Q using Horn's quaternion
@@ -71,6 +71,18 @@ def horn(
         raise ValueError("Horn's method is strictly for 3D point clouds")
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
+
+    if weights is not None:
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match "
+                f"P.shape[:-1] {P.shape[:-1]}"
+            )
+        if torch.any(weights < 0):
+            raise ValueError("weights must be non-negative")
+        if not torch.all(torch.sum(weights, dim=-1) > 0):
+            raise ValueError("weights must sum to a positive value")
+
     orig_dtype = P.dtype
     if P.dtype != Q.dtype:
         # Mixed dtypes: promote to higher precision
@@ -82,25 +94,41 @@ def horn(
         P = P.to(torch.float32)
         Q = Q.to(torch.float32)
 
+    if weights is not None:
+        weights = weights.to(P.dtype)
+
     is_single = P.ndim == 2
     if is_single:
         P = P.unsqueeze(0)
         Q = Q.unsqueeze(0)
+        if weights is not None:
+            weights = weights.unsqueeze(0)
 
     orig_shape = P.shape
     N_pts = orig_shape[-2]
     batch_dims = orig_shape[:-2]
     P = P.reshape(-1, N_pts, 3)
     Q = Q.reshape(-1, N_pts, 3)
+    if weights is not None:
+        weights = weights.reshape(-1, N_pts)
 
     # 1. Compute Centers and 3x3 Cross-Covariance
-    centroid_P = P.mean(dim=1, keepdim=True)
-    centroid_Q = Q.mean(dim=1, keepdim=True)
+    if weights is not None:
+        w = weights.unsqueeze(-1)  # BxNx1
+        w_sum = torch.sum(weights, dim=-1)  # B
+        centroid_P = torch.sum(w * P, dim=1, keepdim=True) / w_sum.view(-1, 1, 1)
+        centroid_Q = torch.sum(w * Q, dim=1, keepdim=True) / w_sum.view(-1, 1, 1)
+    else:
+        centroid_P = P.mean(dim=1, keepdim=True)
+        centroid_Q = Q.mean(dim=1, keepdim=True)
 
     p = P - centroid_P
     q = Q - centroid_Q
 
-    H = torch.matmul(p.transpose(1, 2), q)
+    if weights is not None:
+        H = torch.matmul((w * p).transpose(1, 2), q)
+    else:
+        H = torch.matmul(p.transpose(1, 2), q)
 
     # 2. Construct the 4x4 Symmetric Matrix N
     S = H + H.transpose(-1, -2)
@@ -165,7 +193,11 @@ def horn(
     # RMSD
     aligned = torch.matmul(p, R.transpose(1, 2))
     _eps = torch.finfo(P.dtype).eps
-    mse = torch.sum(torch.square(aligned - q), dim=(1, 2)) / N_pts
+    if weights is not None:
+        residual_sq = torch.sum(torch.square(aligned - q), dim=-1)  # BxN
+        mse = torch.sum(weights * residual_sq, dim=-1) / w_sum  # B
+    else:
+        mse = torch.sum(torch.square(aligned - q), dim=(1, 2)) / N_pts
     rmsd = torch.sqrt(mse + _eps)
 
     if is_single:
@@ -187,7 +219,7 @@ def horn(
 
 
 def horn_with_scale(
-    P: torch.Tensor, Q: torch.Tensor
+    P: torch.Tensor, Q: torch.Tensor, weights: torch.Tensor | None = None
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Computes optimal rotation, translation, and scale using Horn's method.
@@ -204,6 +236,18 @@ def horn_with_scale(
         raise ValueError("Horn's method is strictly for 3D point clouds")
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
+
+    if weights is not None:
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match "
+                f"P.shape[:-1] {P.shape[:-1]}"
+            )
+        if torch.any(weights < 0):
+            raise ValueError("weights must be non-negative")
+        if not torch.all(torch.sum(weights, dim=-1) > 0):
+            raise ValueError("weights must sum to a positive value")
+
     orig_dtype = P.dtype
     if P.dtype != Q.dtype:
         # Mixed dtypes: promote to higher precision
@@ -215,27 +259,42 @@ def horn_with_scale(
         P = P.to(torch.float32)
         Q = Q.to(torch.float32)
 
+    if weights is not None:
+        weights = weights.to(P.dtype)
+
     is_single = P.ndim == 2
     if is_single:
         P = P.unsqueeze(0)
         Q = Q.unsqueeze(0)
+        if weights is not None:
+            weights = weights.unsqueeze(0)
 
     orig_shape = P.shape
     N_pts = orig_shape[-2]
     batch_dims = orig_shape[:-2]
     P = P.reshape(-1, N_pts, 3)
     Q = Q.reshape(-1, N_pts, 3)
+    if weights is not None:
+        weights = weights.reshape(-1, N_pts)
 
-    centroid_P = P.mean(dim=1, keepdim=True)
-    centroid_Q = Q.mean(dim=1, keepdim=True)
+    if weights is not None:
+        w = weights.unsqueeze(-1)  # BxNx1
+        w_sum = torch.sum(weights, dim=-1)  # B
+        centroid_P = torch.sum(w * P, dim=1, keepdim=True) / w_sum.view(-1, 1, 1)
+        centroid_Q = torch.sum(w * Q, dim=1, keepdim=True) / w_sum.view(-1, 1, 1)
+    else:
+        centroid_P = P.mean(dim=1, keepdim=True)
+        centroid_Q = Q.mean(dim=1, keepdim=True)
 
     p = P - centroid_P
     q = Q - centroid_Q
 
-    var_P = torch.sum(torch.square(p), dim=(1, 2)) / N_pts
-
-    # Cross-covariance matrix
-    H = torch.matmul(p.transpose(1, 2), q) / N_pts
+    if weights is not None:
+        var_P = torch.sum(weights * torch.sum(torch.square(p), dim=-1), dim=-1) / w_sum
+        H = torch.matmul((w * p).transpose(1, 2), q) / w_sum.view(-1, 1, 1)
+    else:
+        var_P = torch.sum(torch.square(p), dim=(1, 2)) / N_pts
+        H = torch.matmul(p.transpose(1, 2), q) / N_pts
 
     # S
     S = H + H.transpose(-1, -2)
@@ -299,7 +358,11 @@ def horn_with_scale(
         P, R.transpose(1, 2)
     ) + t.unsqueeze(1)
     diff = aligned_P - Q
-    mse = torch.sum(torch.square(diff), dim=(1, 2)) / N_pts
+    if weights is not None:
+        residual_sq = torch.sum(torch.square(diff), dim=-1)  # BxN
+        mse = torch.sum(weights * residual_sq, dim=-1) / w_sum  # B
+    else:
+        mse = torch.sum(torch.square(diff), dim=(1, 2)) / N_pts
     rmsd = torch.sqrt(mse + _eps)
 
     if is_single:

--- a/src/kabsch_horn/pytorch/kabsch_svd_nd.py
+++ b/src/kabsch_horn/pytorch/kabsch_svd_nd.py
@@ -128,7 +128,7 @@ def safe_svd(
 
 
 def kabsch(
-    P: torch.Tensor, Q: torch.Tensor
+    P: torch.Tensor, Q: torch.Tensor, weights: torch.Tensor | None = None
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Computes the optimal rotation and translation to align P to Q using Safe SVD.
@@ -136,6 +136,8 @@ def kabsch(
     Args:
         P: Source points, shape [..., N, D].
         Q: Target points, shape [..., N, D].
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, rmsd): Rotation [..., D, D], translation [..., D], RMSD [...].
@@ -158,6 +160,17 @@ def kabsch(
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
 
+    if weights is not None:
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match "
+                f"P.shape[:-1] {P.shape[:-1]}"
+            )
+        if torch.any(weights < 0):
+            raise ValueError("weights must be non-negative")
+        if not torch.all(torch.sum(weights, dim=-1) > 0):
+            raise ValueError("weights must sum to a positive value")
+
     orig_dtype = P.dtype
     if P.dtype != Q.dtype:
         # Mixed dtypes: promote to higher precision
@@ -169,10 +182,15 @@ def kabsch(
         P = P.to(torch.float32)
         Q = Q.to(torch.float32)
 
+    if weights is not None:
+        weights = weights.to(P.dtype)
+
     is_single = P.ndim == 2
     if is_single:
         P = P.unsqueeze(0)
         Q = Q.unsqueeze(0)
+        if weights is not None:
+            weights = weights.unsqueeze(0)
 
     orig_shape = P.shape
     D = orig_shape[-1]
@@ -181,17 +199,30 @@ def kabsch(
 
     P = P.view(-1, _N, D)
     Q = Q.view(-1, _N, D)
+    if weights is not None:
+        weights = weights.view(-1, _N)
 
     # Compute centroids
-    centroid_P = torch.mean(P, dim=1, keepdim=True)  # Bx1x3
-    centroid_Q = torch.mean(Q, dim=1, keepdim=True)  # Bx1x3
+    if weights is not None:
+        w = weights.unsqueeze(-1)  # BxNx1
+        w_sum = torch.sum(weights, dim=-1)  # B
+        centroid_P = torch.sum(w * P, dim=1, keepdim=True) / w_sum.view(
+            -1, 1, 1
+        )  # Bx1xD
+        centroid_Q = torch.sum(w * Q, dim=1, keepdim=True) / w_sum.view(-1, 1, 1)
+    else:
+        centroid_P = torch.mean(P, dim=1, keepdim=True)  # Bx1x3
+        centroid_Q = torch.mean(Q, dim=1, keepdim=True)  # Bx1x3
 
     # Center points
     p = P - centroid_P  # BxNx3
     q = Q - centroid_Q  # BxNx3
 
     # Cross-covariance matrix
-    H = torch.matmul(p.transpose(1, 2), q)  # Bx3x3
+    if weights is not None:
+        H = torch.matmul((w * p).transpose(1, 2), q)  # BxDxD
+    else:
+        H = torch.matmul(p.transpose(1, 2), q)  # Bx3x3
 
     # Safe SVD
     U, _S, V = safe_svd(H)  # Bx3x3, Bx3, Bx3x3
@@ -218,7 +249,11 @@ def kabsch(
     # RMSD (mse + eps for smooth sqrt gradient near zero)
     aligned = torch.matmul(p, R.transpose(1, 2))
     _eps = torch.finfo(P.dtype).eps
-    mse = torch.sum(torch.square(aligned - q), dim=(1, 2)) / P.shape[1]
+    if weights is not None:
+        residual_sq = torch.sum(torch.square(aligned - q), dim=-1)  # BxN
+        mse = torch.sum(weights * residual_sq, dim=-1) / w_sum  # B
+    else:
+        mse = torch.sum(torch.square(aligned - q), dim=(1, 2)) / P.shape[1]
     rmsd = torch.sqrt(mse + _eps)
 
     # Fast Translation
@@ -247,7 +282,7 @@ def kabsch(
 
 
 def kabsch_umeyama(
-    P: torch.Tensor, Q: torch.Tensor
+    P: torch.Tensor, Q: torch.Tensor, weights: torch.Tensor | None = None
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Computes optimal rotation, translation, and scale (Q ~ c * R @ P + t).
@@ -255,6 +290,8 @@ def kabsch_umeyama(
     Args:
         P: Source points, shape [..., N, D].
         Q: Target points, shape [..., N, D].
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, c, rmsd): Rotation [..., D, D], translation [..., D], scale [...],
@@ -282,6 +319,17 @@ def kabsch_umeyama(
     if P.shape[-2] < 2:
         raise ValueError("At least 2 points are required for alignment")
 
+    if weights is not None:
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match "
+                f"P.shape[:-1] {P.shape[:-1]}"
+            )
+        if torch.any(weights < 0):
+            raise ValueError("weights must be non-negative")
+        if not torch.all(torch.sum(weights, dim=-1) > 0):
+            raise ValueError("weights must sum to a positive value")
+
     orig_dtype = P.dtype
     if P.dtype != Q.dtype:
         # Mixed dtypes: promote to higher precision
@@ -293,10 +341,15 @@ def kabsch_umeyama(
         P = P.to(torch.float32)
         Q = Q.to(torch.float32)
 
+    if weights is not None:
+        weights = weights.to(P.dtype)
+
     is_single = P.ndim == 2
     if is_single:
         P = P.unsqueeze(0)
         Q = Q.unsqueeze(0)
+        if weights is not None:
+            weights = weights.unsqueeze(0)
 
     orig_shape = P.shape
     D = orig_shape[-1]
@@ -305,20 +358,30 @@ def kabsch_umeyama(
 
     P = P.view(-1, N, D)
     Q = Q.view(-1, N, D)
+    if weights is not None:
+        weights = weights.view(-1, N)
 
     # Compute centroids
-    centroid_P = torch.mean(P, dim=1, keepdim=True)
-    centroid_Q = torch.mean(Q, dim=1, keepdim=True)
+    if weights is not None:
+        w = weights.unsqueeze(-1)  # BxNx1
+        w_sum = torch.sum(weights, dim=-1)  # B
+        centroid_P = torch.sum(w * P, dim=1, keepdim=True) / w_sum.view(-1, 1, 1)
+        centroid_Q = torch.sum(w * Q, dim=1, keepdim=True) / w_sum.view(-1, 1, 1)
+    else:
+        centroid_P = torch.mean(P, dim=1, keepdim=True)
+        centroid_Q = torch.mean(Q, dim=1, keepdim=True)
 
     # Center points
     p = P - centroid_P
     q = Q - centroid_Q
 
-    # Cross-covariance matrix (divided by N for Umeyama scale estimation)
-    H = torch.matmul(p.transpose(1, 2), q) / N
-
-    # Variances of P
-    var_P = torch.sum(torch.square(p), dim=(1, 2)) / N
+    # Cross-covariance matrix (divided by N or w_sum for Umeyama scale estimation)
+    if weights is not None:
+        H = torch.matmul((w * p).transpose(1, 2), q) / w_sum.view(-1, 1, 1)
+        var_P = torch.sum(weights * torch.sum(torch.square(p), dim=-1), dim=-1) / w_sum
+    else:
+        H = torch.matmul(p.transpose(1, 2), q) / N
+        var_P = torch.sum(torch.square(p), dim=(1, 2)) / N
 
     # Safe SVD
     U, S, V = safe_svd(H)
@@ -351,7 +414,11 @@ def kabsch_umeyama(
     aligned_P = c.unsqueeze(-1).unsqueeze(-1) * torch.matmul(
         P, R.transpose(1, 2)
     ) + t.unsqueeze(1)
-    mse = torch.sum(torch.square(aligned_P - Q), dim=(1, 2)) / N
+    if weights is not None:
+        residual_sq = torch.sum(torch.square(aligned_P - Q), dim=-1)  # BxN
+        mse = torch.sum(weights * residual_sq, dim=-1) / w_sum  # B
+    else:
+        mse = torch.sum(torch.square(aligned_P - Q), dim=(1, 2)) / N
     rmsd = torch.sqrt(mse + _eps)
 
     if is_single:
@@ -379,13 +446,17 @@ def kabsch_umeyama(
     return R, t, c, rmsd
 
 
-def kabsch_rmsd(P: torch.Tensor, Q: torch.Tensor) -> torch.Tensor:
+def kabsch_rmsd(
+    P: torch.Tensor, Q: torch.Tensor, weights: torch.Tensor | None = None
+) -> torch.Tensor:
     """Computes RMSD after Kabsch alignment. Gradient-safe training loss."""
-    _R, _t, rmsd = kabsch(P, Q)
+    _R, _t, rmsd = kabsch(P, Q, weights=weights)
     return rmsd
 
 
-def kabsch_umeyama_rmsd(P: torch.Tensor, Q: torch.Tensor) -> torch.Tensor:
+def kabsch_umeyama_rmsd(
+    P: torch.Tensor, Q: torch.Tensor, weights: torch.Tensor | None = None
+) -> torch.Tensor:
     """Computes RMSD after Kabsch-Umeyama alignment. Gradient-safe training loss."""
-    _R, _t, _c, rmsd = kabsch_umeyama(P, Q)
+    _R, _t, _c, rmsd = kabsch_umeyama(P, Q, weights=weights)
     return rmsd

--- a/src/kabsch_horn/tensorflow/horn_quat_3d.py
+++ b/src/kabsch_horn/tensorflow/horn_quat_3d.py
@@ -53,7 +53,8 @@ def horn(
     Args:
         P: Source points, shape [..., N, 3].
         Q: Target points, shape [..., N, 3].
-        weights: Per-point weights, shape [..., N]. If None, uniform weights.
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, rmsd): Rotation [..., 3, 3], translation [..., 3], and RMSD [...].
@@ -229,7 +230,8 @@ def horn_with_scale(
     Args:
         P: Source points, shape [..., N, 3].
         Q: Target points, shape [..., N, 3].
-        weights: Per-point weights, shape [..., N]. If None, uniform weights.
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, c, rmsd): Rotation [..., 3, 3], translation [..., 3],

--- a/src/kabsch_horn/tensorflow/horn_quat_3d.py
+++ b/src/kabsch_horn/tensorflow/horn_quat_3d.py
@@ -40,7 +40,9 @@ def call_safe_eigh(A: tf.Tensor) -> tuple[tf.Tensor, ...]:
     return (L, V), grad
 
 
-def horn(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
+def horn(
+    P: tf.Tensor, Q: tf.Tensor, weights: tf.Tensor | None = None
+) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
     """
     Computes optimal rotation and translation to align P to Q using Horn's
     quaternion method.
@@ -51,6 +53,7 @@ def horn(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
     Args:
         P: Source points, shape [..., N, 3].
         Q: Target points, shape [..., N, 3].
+        weights: Per-point weights, shape [..., N]. If None, uniform weights.
 
     Returns:
         (R, t, rmsd): Rotation [..., 3, 3], translation [..., 3], and RMSD [...].
@@ -84,6 +87,22 @@ def horn(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
         tf.shape(P)[-2], 2, message="At least 2 points are required for alignment"
     )
 
+    if weights is not None:
+        weights = tf.convert_to_tensor(weights)
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match"
+                f" P.shape[:-1] {P.shape[:-1]}"
+            )
+        weights = tf.cast(weights, P.dtype)
+        tf.debugging.assert_non_negative(
+            weights, message="weights must be non-negative"
+        )
+        tf.debugging.assert_positive(
+            tf.reduce_sum(weights, axis=-1),
+            message="weights must sum to a positive value",
+        )
+
     orig_dtype = P.dtype
     if P.dtype != Q.dtype:
         # Mixed dtypes: promote to higher precision
@@ -95,18 +114,33 @@ def horn(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
         P = tf.cast(P, tf.float32)
         Q = tf.cast(Q, tf.float32)
 
+    if weights is not None:
+        weights = tf.cast(weights, P.dtype)
+
     is_single = len(P.shape) == 2
     if is_single:
         P = tf.expand_dims(P, 0)
         Q = tf.expand_dims(Q, 0)
+        if weights is not None:
+            weights = tf.expand_dims(weights, 0)
 
-    centroid_P = tf.reduce_mean(P, axis=-2, keepdims=True)
-    centroid_Q = tf.reduce_mean(Q, axis=-2, keepdims=True)
+    if weights is not None:
+        w = tf.expand_dims(weights, -1)  # [..., N, 1]
+        w_sum = tf.reduce_sum(weights, axis=-1)  # [...]
+        w_sum_exp = tf.expand_dims(tf.expand_dims(w_sum, -1), -1)  # [..., 1, 1]
+        centroid_P = tf.reduce_sum(w * P, axis=-2, keepdims=True) / w_sum_exp
+        centroid_Q = tf.reduce_sum(w * Q, axis=-2, keepdims=True) / w_sum_exp
+    else:
+        centroid_P = tf.reduce_mean(P, axis=-2, keepdims=True)
+        centroid_Q = tf.reduce_mean(Q, axis=-2, keepdims=True)
 
     p = P - centroid_P
     q = Q - centroid_Q
 
-    H = tf.matmul(p, q, transpose_a=True)
+    if weights is not None:
+        H = tf.matmul(w * p, q, transpose_a=True)
+    else:
+        H = tf.matmul(p, q, transpose_a=True)
 
     S = H + tf.linalg.matrix_transpose(H)
     tr = tf.linalg.trace(H)
@@ -165,9 +199,13 @@ def horn(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
     )
 
     aligned = tf.matmul(p, R, transpose_b=True)
-    N_pts_f = tf.cast(tf.shape(P)[-2], P.dtype)
     _eps = np.finfo(P.dtype.as_numpy_dtype).eps
-    mse = tf.reduce_sum(tf.square(aligned - q), axis=[-2, -1]) / N_pts_f
+    if weights is not None:
+        residual_sq = tf.reduce_sum(tf.square(aligned - q), axis=-1)  # [..., N]
+        mse = tf.reduce_sum(weights * residual_sq, axis=-1) / w_sum
+    else:
+        N_pts_f = tf.cast(tf.shape(P)[-2], P.dtype)
+        mse = tf.reduce_sum(tf.square(aligned - q), axis=[-2, -1]) / N_pts_f
     rmsd = tf.sqrt(mse + _eps)
 
     if is_single:
@@ -180,7 +218,7 @@ def horn(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
 
 
 def horn_with_scale(
-    P: tf.Tensor, Q: tf.Tensor
+    P: tf.Tensor, Q: tf.Tensor, weights: tf.Tensor | None = None
 ) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor, tf.Tensor]:
     """
     Computes optimal rotation, translation, and scale to align P to Q
@@ -191,6 +229,7 @@ def horn_with_scale(
     Args:
         P: Source points, shape [..., N, 3].
         Q: Target points, shape [..., N, 3].
+        weights: Per-point weights, shape [..., N]. If None, uniform weights.
 
     Returns:
         (R, t, c, rmsd): Rotation [..., 3, 3], translation [..., 3],
@@ -225,6 +264,22 @@ def horn_with_scale(
         tf.shape(P)[-2], 2, message="At least 2 points are required for alignment"
     )
 
+    if weights is not None:
+        weights = tf.convert_to_tensor(weights)
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match"
+                f" P.shape[:-1] {P.shape[:-1]}"
+            )
+        weights = tf.cast(weights, P.dtype)
+        tf.debugging.assert_non_negative(
+            weights, message="weights must be non-negative"
+        )
+        tf.debugging.assert_positive(
+            tf.reduce_sum(weights, axis=-1),
+            message="weights must sum to a positive value",
+        )
+
     orig_dtype = P.dtype
     if P.dtype != Q.dtype:
         # Mixed dtypes: promote to higher precision
@@ -236,21 +291,37 @@ def horn_with_scale(
         P = tf.cast(P, tf.float32)
         Q = tf.cast(Q, tf.float32)
 
+    if weights is not None:
+        weights = tf.cast(weights, P.dtype)
+
     is_single = len(P.shape) == 2
     if is_single:
         P = tf.expand_dims(P, 0)
         Q = tf.expand_dims(Q, 0)
+        if weights is not None:
+            weights = tf.expand_dims(weights, 0)
 
-    centroid_P = tf.reduce_mean(P, axis=-2, keepdims=True)
-    centroid_Q = tf.reduce_mean(Q, axis=-2, keepdims=True)
+    if weights is not None:
+        w = tf.expand_dims(weights, -1)  # [..., N, 1]
+        w_sum = tf.reduce_sum(weights, axis=-1)  # [...]
+        w_sum_exp = tf.expand_dims(tf.expand_dims(w_sum, -1), -1)  # [..., 1, 1]
+        centroid_P = tf.reduce_sum(w * P, axis=-2, keepdims=True) / w_sum_exp
+        centroid_Q = tf.reduce_sum(w * Q, axis=-2, keepdims=True) / w_sum_exp
+    else:
+        centroid_P = tf.reduce_mean(P, axis=-2, keepdims=True)
+        centroid_Q = tf.reduce_mean(Q, axis=-2, keepdims=True)
 
     p = P - centroid_P
     q = Q - centroid_Q
 
-    N_pts_f = tf.cast(tf.shape(P)[-2], P.dtype)
-    var_P = tf.reduce_sum(tf.square(p), axis=[-2, -1]) / N_pts_f
-
-    H = tf.matmul(p, q, transpose_a=True) / N_pts_f
+    if weights is not None:
+        weighted_sq = weights * tf.reduce_sum(tf.square(p), axis=-1)
+        var_P = tf.reduce_sum(weighted_sq, axis=-1) / w_sum
+        H = tf.matmul(w * p, q, transpose_a=True) / w_sum_exp
+    else:
+        N_pts_f = tf.cast(tf.shape(P)[-2], P.dtype)
+        var_P = tf.reduce_sum(tf.square(p), axis=[-2, -1]) / N_pts_f
+        H = tf.matmul(p, q, transpose_a=True) / N_pts_f
 
     S = H + tf.linalg.matrix_transpose(H)
     tr = tf.linalg.trace(H)
@@ -316,7 +387,12 @@ def horn_with_scale(
         P, R, transpose_b=True
     ) + tf.expand_dims(t, -2)
     diff = aligned_P - Q
-    mse = tf.reduce_sum(tf.square(diff), axis=[-2, -1]) / N_pts_f
+    if weights is not None:
+        residual_sq = tf.reduce_sum(tf.square(diff), axis=-1)  # [..., N]
+        mse = tf.reduce_sum(weights * residual_sq, axis=-1) / w_sum
+    else:
+        N_pts_f = tf.cast(tf.shape(P)[-2], P.dtype)
+        mse = tf.reduce_sum(tf.square(diff), axis=[-2, -1]) / N_pts_f
     rmsd = tf.sqrt(mse + _eps)
 
     if is_single:

--- a/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
+++ b/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
@@ -94,7 +94,8 @@ def kabsch(
     Args:
         P: Source points, shape [..., N, D].
         Q: Target points, shape [..., N, D].
-        weights: Per-point weights, shape [..., N]. If None, uniform weights.
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, rmsd): Rotation [..., D, D], translation [..., D], RMSD [...].
@@ -238,7 +239,8 @@ def kabsch_umeyama(
     Args:
         P: Source points, shape [..., N, D].
         Q: Target points, shape [..., N, D].
-        weights: Per-point weights, shape [..., N]. If None, uniform weights.
+        weights: Per-point weights, shape [..., N]. Non-negative, must sum to > 0.
+            When None, all points are weighted equally.
 
     Returns:
         (R, t, c, rmsd): Rotation [..., D, D], translation [..., D], scale [...],

--- a/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
+++ b/src/kabsch_horn/tensorflow/kabsch_svd_nd.py
@@ -85,13 +85,16 @@ def safe_svd(A: tf.Tensor) -> tuple[tf.Tensor, ...]:
     return (S, U, V), grad
 
 
-def kabsch(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
+def kabsch(
+    P: tf.Tensor, Q: tf.Tensor, weights: tf.Tensor | None = None
+) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
     """
     Computes the optimal rotation and translation to align P to Q.
 
     Args:
         P: Source points, shape [..., N, D].
         Q: Target points, shape [..., N, D].
+        weights: Per-point weights, shape [..., N]. If None, uniform weights.
 
     Returns:
         (R, t, rmsd): Rotation [..., D, D], translation [..., D], RMSD [...].
@@ -123,6 +126,22 @@ def kabsch(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]
         tf.shape(P)[-2], 2, message="At least 2 points are required for alignment"
     )
 
+    if weights is not None:
+        weights = tf.convert_to_tensor(weights)
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match"
+                f" P.shape[:-1] {P.shape[:-1]}"
+            )
+        weights = tf.cast(weights, P.dtype)
+        tf.debugging.assert_non_negative(
+            weights, message="weights must be non-negative"
+        )
+        tf.debugging.assert_positive(
+            tf.reduce_sum(weights, axis=-1),
+            message="weights must sum to a positive value",
+        )
+
     orig_dtype = P.dtype
     if P.dtype != Q.dtype:
         # Mixed dtypes: promote to higher precision
@@ -134,15 +153,28 @@ def kabsch(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]
         P = tf.cast(P, tf.float32)
         Q = tf.cast(Q, tf.float32)
 
+    if weights is not None:
+        weights = tf.cast(weights, P.dtype)
+
     # Centering
-    centroid_P = tf.reduce_mean(P, axis=-2, keepdims=True)
-    centroid_Q = tf.reduce_mean(Q, axis=-2, keepdims=True)
+    if weights is not None:
+        w = tf.expand_dims(weights, -1)  # [..., N, 1]
+        w_sum = tf.reduce_sum(weights, axis=-1)  # [...]
+        w_sum_exp = tf.expand_dims(tf.expand_dims(w_sum, -1), -1)  # [..., 1, 1]
+        centroid_P = tf.reduce_sum(w * P, axis=-2, keepdims=True) / w_sum_exp
+        centroid_Q = tf.reduce_sum(w * Q, axis=-2, keepdims=True) / w_sum_exp
+    else:
+        centroid_P = tf.reduce_mean(P, axis=-2, keepdims=True)
+        centroid_Q = tf.reduce_mean(Q, axis=-2, keepdims=True)
 
     p = P - centroid_P
     q = Q - centroid_Q
 
-    N = tf.cast(tf.shape(P)[-2], P.dtype)
-    H = tf.matmul(p, q, transpose_a=True) / N
+    if weights is not None:
+        H = tf.matmul(w * p, q, transpose_a=True) / w_sum_exp
+    else:
+        N = tf.cast(tf.shape(P)[-2], P.dtype)
+        H = tf.matmul(p, q, transpose_a=True) / N
 
     # SVD
     _S, U, V = safe_svd(H)
@@ -182,7 +214,11 @@ def kabsch(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]
     P_aligned = tf.matmul(P, R, transpose_b=True) + tf.expand_dims(t, -2)
     diff = P_aligned - Q
     _eps = np.finfo(P.dtype.as_numpy_dtype).eps
-    mse = tf.reduce_mean(tf.reduce_sum(tf.square(diff), axis=-1), axis=-1)
+    if weights is not None:
+        residual_sq = tf.reduce_sum(tf.square(diff), axis=-1)  # [..., N]
+        mse = tf.reduce_sum(weights * residual_sq, axis=-1) / w_sum
+    else:
+        mse = tf.reduce_mean(tf.reduce_sum(tf.square(diff), axis=-1), axis=-1)
     rmsd = tf.sqrt(mse + _eps)
 
     if orig_dtype in (tf.float16, tf.bfloat16):
@@ -194,7 +230,7 @@ def kabsch(P: tf.Tensor, Q: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]
 
 
 def kabsch_umeyama(
-    P: tf.Tensor, Q: tf.Tensor
+    P: tf.Tensor, Q: tf.Tensor, weights: tf.Tensor | None = None
 ) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor, tf.Tensor]:
     """
     Computes the optimal rotation, translation, and scale (Q ~ c * R @ P + t).
@@ -202,6 +238,7 @@ def kabsch_umeyama(
     Args:
         P: Source points, shape [..., N, D].
         Q: Target points, shape [..., N, D].
+        weights: Per-point weights, shape [..., N]. If None, uniform weights.
 
     Returns:
         (R, t, c, rmsd): Rotation [..., D, D], translation [..., D], scale [...],
@@ -238,6 +275,22 @@ def kabsch_umeyama(
         tf.shape(P)[-2], 2, message="At least 2 points are required for alignment"
     )
 
+    if weights is not None:
+        weights = tf.convert_to_tensor(weights)
+        if weights.shape != P.shape[:-1]:
+            raise ValueError(
+                f"weights shape {weights.shape} does not match"
+                f" P.shape[:-1] {P.shape[:-1]}"
+            )
+        weights = tf.cast(weights, P.dtype)
+        tf.debugging.assert_non_negative(
+            weights, message="weights must be non-negative"
+        )
+        tf.debugging.assert_positive(
+            tf.reduce_sum(weights, axis=-1),
+            message="weights must sum to a positive value",
+        )
+
     orig_dtype = P.dtype
     if P.dtype != Q.dtype:
         # Mixed dtypes: promote to higher precision
@@ -249,21 +302,38 @@ def kabsch_umeyama(
         P = tf.cast(P, tf.float32)
         Q = tf.cast(Q, tf.float32)
 
+    if weights is not None:
+        weights = tf.cast(weights, P.dtype)
+
     # Centering
-    centroid_P = tf.reduce_mean(P, axis=-2, keepdims=True)
-    centroid_Q = tf.reduce_mean(Q, axis=-2, keepdims=True)
+    if weights is not None:
+        w = tf.expand_dims(weights, -1)  # [..., N, 1]
+        w_sum = tf.reduce_sum(weights, axis=-1)  # [...]
+        w_sum_exp = tf.expand_dims(tf.expand_dims(w_sum, -1), -1)  # [..., 1, 1]
+        centroid_P = tf.reduce_sum(w * P, axis=-2, keepdims=True) / w_sum_exp
+        centroid_Q = tf.reduce_sum(w * Q, axis=-2, keepdims=True) / w_sum_exp
+    else:
+        centroid_P = tf.reduce_mean(P, axis=-2, keepdims=True)
+        centroid_Q = tf.reduce_mean(Q, axis=-2, keepdims=True)
 
     p = P - centroid_P
     q = Q - centroid_Q
 
     # Variance of P
-    var_P = tf.reduce_sum(tf.square(p), axis=[-2, -1]) / tf.cast(
-        tf.shape(P)[-2], P.dtype
-    )
+    if weights is not None:
+        weighted_sq = weights * tf.reduce_sum(tf.square(p), axis=-1)
+        var_P = tf.reduce_sum(weighted_sq, axis=-1) / w_sum
+    else:
+        var_P = tf.reduce_sum(tf.square(p), axis=[-2, -1]) / tf.cast(
+            tf.shape(P)[-2], P.dtype
+        )
 
     # Cross-covariance matrix (divided by N for Umeyama scale estimation)
-    N = tf.cast(tf.shape(P)[-2], P.dtype)
-    H = tf.matmul(p, q, transpose_a=True) / N
+    if weights is not None:
+        H = tf.matmul(w * p, q, transpose_a=True) / w_sum_exp
+    else:
+        N = tf.cast(tf.shape(P)[-2], P.dtype)
+        H = tf.matmul(p, q, transpose_a=True) / N
 
     # SVD
     S, U, V_m = safe_svd(H)
@@ -308,7 +378,11 @@ def kabsch_umeyama(
     c_exp = tf.expand_dims(tf.expand_dims(c, -1), -1)
     P_aligned = c_exp * tf.matmul(P, R, transpose_b=True) + tf.expand_dims(t, -2)
     diff = P_aligned - Q
-    mse = tf.reduce_mean(tf.reduce_sum(tf.square(diff), axis=-1), axis=-1)
+    if weights is not None:
+        residual_sq = tf.reduce_sum(tf.square(diff), axis=-1)  # [..., N]
+        mse = tf.reduce_sum(weights * residual_sq, axis=-1) / w_sum
+    else:
+        mse = tf.reduce_mean(tf.reduce_sum(tf.square(diff), axis=-1), axis=-1)
     rmsd = tf.sqrt(mse + _eps)
 
     if orig_dtype in (tf.float16, tf.bfloat16):
@@ -322,13 +396,17 @@ def kabsch_umeyama(
     return R, t, c, rmsd
 
 
-def kabsch_rmsd(P: tf.Tensor, Q: tf.Tensor) -> tf.Tensor:
+def kabsch_rmsd(
+    P: tf.Tensor, Q: tf.Tensor, weights: tf.Tensor | None = None
+) -> tf.Tensor:
     """Computes RMSD after Kabsch alignment."""
-    _R, _t, rmsd = kabsch(P, Q)
+    _R, _t, rmsd = kabsch(P, Q, weights=weights)
     return rmsd
 
 
-def kabsch_umeyama_rmsd(P: tf.Tensor, Q: tf.Tensor) -> tf.Tensor:
+def kabsch_umeyama_rmsd(
+    P: tf.Tensor, Q: tf.Tensor, weights: tf.Tensor | None = None
+) -> tf.Tensor:
     """Computes RMSD after Kabsch-Umeyama alignment."""
-    _R, _t, _c, rmsd = kabsch_umeyama(P, Q)
+    _R, _t, _c, rmsd = kabsch_umeyama(P, Q, weights=weights)
     return rmsd

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -74,25 +74,25 @@ class FrameworkAdapter(Generic[T]):
     def convert_out(self, obj: T) -> np.ndarray:
         raise NotImplementedError
 
-    def kabsch(self, P: T, Q: T) -> tuple[T, ...]:
+    def kabsch(self, P: T, Q: T, weights: T | None = None) -> tuple[T, ...]:
         raise NotImplementedError
 
-    def kabsch_umeyama(self, P: T, Q: T) -> tuple[T, ...]:
+    def kabsch_umeyama(self, P: T, Q: T, weights: T | None = None) -> tuple[T, ...]:
         raise NotImplementedError
 
-    def horn(self, P: T, Q: T) -> tuple[T, ...]:
+    def horn(self, P: T, Q: T, weights: T | None = None) -> tuple[T, ...]:
         raise NotImplementedError
 
-    def horn_with_scale(self, P: T, Q: T) -> tuple[T, ...]:
+    def horn_with_scale(self, P: T, Q: T, weights: T | None = None) -> tuple[T, ...]:
         raise NotImplementedError
 
-    def kabsch_rmsd(self, P: T, Q: T) -> T:
+    def kabsch_rmsd(self, P: T, Q: T, weights: T | None = None) -> T:
         raise NotImplementedError
 
-    def kabsch_umeyama_rmsd(self, P: T, Q: T) -> T:
+    def kabsch_umeyama_rmsd(self, P: T, Q: T, weights: T | None = None) -> T:
         raise NotImplementedError
 
-    def get_transform_func(self, algo: str) -> Callable[[T, T], tuple[T, ...]]:
+    def get_transform_func(self, algo: str) -> Callable:
         """Returns the corresponding transformation function for the given algorithm."""
         if algo == "kabsch":
             return self.kabsch
@@ -111,7 +111,7 @@ class FrameworkAdapter(Generic[T]):
         self,
         P: T,
         Q: T,
-        func: Callable[[T, T], tuple[T, ...]],
+        func: Callable,
         seed: int | None = 42,
         wrt: str = "P",
     ) -> np.ndarray:
@@ -155,27 +155,53 @@ try:
                 return obj.detach().numpy()
             return obj
 
-        def kabsch(self, P: torch.Tensor, Q: torch.Tensor) -> tuple[torch.Tensor, ...]:
-            return kabsch_torch.kabsch(P, Q)
+        def kabsch(
+            self,
+            P: torch.Tensor,
+            Q: torch.Tensor,
+            weights: torch.Tensor | None = None,
+        ) -> tuple[torch.Tensor, ...]:
+            return kabsch_torch.kabsch(P, Q, weights=weights)
 
         def kabsch_umeyama(
-            self, P: torch.Tensor, Q: torch.Tensor
+            self,
+            P: torch.Tensor,
+            Q: torch.Tensor,
+            weights: torch.Tensor | None = None,
         ) -> tuple[torch.Tensor, ...]:
-            return kabsch_torch.kabsch_umeyama(P, Q)
+            return kabsch_torch.kabsch_umeyama(P, Q, weights=weights)
 
-        def horn(self, P: torch.Tensor, Q: torch.Tensor) -> tuple[torch.Tensor, ...]:
-            return kabsch_torch.horn(P, Q)
+        def horn(
+            self,
+            P: torch.Tensor,
+            Q: torch.Tensor,
+            weights: torch.Tensor | None = None,
+        ) -> tuple[torch.Tensor, ...]:
+            return kabsch_torch.horn(P, Q, weights=weights)
 
         def horn_with_scale(
-            self, P: torch.Tensor, Q: torch.Tensor
+            self,
+            P: torch.Tensor,
+            Q: torch.Tensor,
+            weights: torch.Tensor | None = None,
         ) -> tuple[torch.Tensor, ...]:
-            return kabsch_torch.horn_with_scale(P, Q)
+            return kabsch_torch.horn_with_scale(P, Q, weights=weights)
 
-        def kabsch_rmsd(self, P: torch.Tensor, Q: torch.Tensor) -> torch.Tensor:
-            return kabsch_torch.kabsch_rmsd(P, Q)
+        def kabsch_rmsd(
+            self,
+            P: torch.Tensor,
+            Q: torch.Tensor,
+            weights: torch.Tensor | None = None,
+        ) -> torch.Tensor:
+            return kabsch_torch.kabsch_rmsd(P, Q, weights=weights)
 
-        def kabsch_umeyama_rmsd(self, P: torch.Tensor, Q: torch.Tensor) -> torch.Tensor:
-            return kabsch_torch.kabsch_umeyama_rmsd(P, Q)
+        def kabsch_umeyama_rmsd(
+            self,
+            P: torch.Tensor,
+            Q: torch.Tensor,
+            weights: torch.Tensor | None = None,
+        ) -> torch.Tensor:
+            return kabsch_torch.kabsch_umeyama_rmsd(P, Q, weights=weights)
 
         def is_nan(self, tensor: torch.Tensor) -> bool:
             return torch.isnan(tensor).any().item()
@@ -184,7 +210,7 @@ try:
             self,
             P: torch.Tensor,
             Q: torch.Tensor,
-            func: Callable[[torch.Tensor, torch.Tensor], tuple[torch.Tensor, ...]],
+            func: Callable,
             seed: int | None = 42,
             wrt: str = "P",
         ) -> np.ndarray:
@@ -249,23 +275,35 @@ try:
                 obj = obj.astype(jnp.float32)
             return np.array(obj)
 
-        def kabsch(self, P: jax.Array, Q: jax.Array) -> tuple[jax.Array, ...]:
-            return kabsch_jax.kabsch(P, Q)
+        def kabsch(
+            self, P: jax.Array, Q: jax.Array, weights: jax.Array | None = None
+        ) -> tuple[jax.Array, ...]:
+            return kabsch_jax.kabsch(P, Q, weights=weights)
 
-        def kabsch_umeyama(self, P: jax.Array, Q: jax.Array) -> tuple[jax.Array, ...]:
-            return kabsch_jax.kabsch_umeyama(P, Q)
+        def kabsch_umeyama(
+            self, P: jax.Array, Q: jax.Array, weights: jax.Array | None = None
+        ) -> tuple[jax.Array, ...]:
+            return kabsch_jax.kabsch_umeyama(P, Q, weights=weights)
 
-        def horn(self, P: jax.Array, Q: jax.Array) -> tuple[jax.Array, ...]:
-            return kabsch_jax.horn(P, Q)
+        def horn(
+            self, P: jax.Array, Q: jax.Array, weights: jax.Array | None = None
+        ) -> tuple[jax.Array, ...]:
+            return kabsch_jax.horn(P, Q, weights=weights)
 
-        def horn_with_scale(self, P: jax.Array, Q: jax.Array) -> tuple[jax.Array, ...]:
-            return kabsch_jax.horn_with_scale(P, Q)
+        def horn_with_scale(
+            self, P: jax.Array, Q: jax.Array, weights: jax.Array | None = None
+        ) -> tuple[jax.Array, ...]:
+            return kabsch_jax.horn_with_scale(P, Q, weights=weights)
 
-        def kabsch_rmsd(self, P: jax.Array, Q: jax.Array) -> jax.Array:
-            return kabsch_jax.kabsch_rmsd(P, Q)
+        def kabsch_rmsd(
+            self, P: jax.Array, Q: jax.Array, weights: jax.Array | None = None
+        ) -> jax.Array:
+            return kabsch_jax.kabsch_rmsd(P, Q, weights=weights)
 
-        def kabsch_umeyama_rmsd(self, P: jax.Array, Q: jax.Array) -> jax.Array:
-            return kabsch_jax.kabsch_umeyama_rmsd(P, Q)
+        def kabsch_umeyama_rmsd(
+            self, P: jax.Array, Q: jax.Array, weights: jax.Array | None = None
+        ) -> jax.Array:
+            return kabsch_jax.kabsch_umeyama_rmsd(P, Q, weights=weights)
 
         def is_nan(self, tensor: jax.Array) -> bool:
             return jnp.isnan(tensor).any()
@@ -274,7 +312,7 @@ try:
             self,
             P: jax.Array,
             Q: jax.Array,
-            func: Callable[[jax.Array, jax.Array], tuple[jax.Array, ...]],
+            func: Callable,
             seed: int | None = 42,
             wrt: str = "P",
         ) -> np.ndarray:
@@ -339,34 +377,52 @@ try:
             return obj.numpy()
 
         def kabsch(
-            self, P: tf.Tensor | tf.Variable, Q: tf.Tensor | tf.Variable
+            self,
+            P: tf.Tensor | tf.Variable,
+            Q: tf.Tensor | tf.Variable,
+            weights: tf.Tensor | tf.Variable | None = None,
         ) -> tuple[tf.Tensor | tf.Variable, ...]:
-            return kabsch_tf.kabsch(P, Q)
+            return kabsch_tf.kabsch(P, Q, weights=weights)
 
         def kabsch_umeyama(
-            self, P: tf.Tensor | tf.Variable, Q: tf.Tensor | tf.Variable
+            self,
+            P: tf.Tensor | tf.Variable,
+            Q: tf.Tensor | tf.Variable,
+            weights: tf.Tensor | tf.Variable | None = None,
         ) -> tuple[tf.Tensor | tf.Variable, ...]:
-            return kabsch_tf.kabsch_umeyama(P, Q)
+            return kabsch_tf.kabsch_umeyama(P, Q, weights=weights)
 
         def horn(
-            self, P: tf.Tensor | tf.Variable, Q: tf.Tensor | tf.Variable
+            self,
+            P: tf.Tensor | tf.Variable,
+            Q: tf.Tensor | tf.Variable,
+            weights: tf.Tensor | tf.Variable | None = None,
         ) -> tuple[tf.Tensor | tf.Variable, ...]:
-            return kabsch_tf.horn(P, Q)
+            return kabsch_tf.horn(P, Q, weights=weights)
 
         def horn_with_scale(
-            self, P: tf.Tensor | tf.Variable, Q: tf.Tensor | tf.Variable
+            self,
+            P: tf.Tensor | tf.Variable,
+            Q: tf.Tensor | tf.Variable,
+            weights: tf.Tensor | tf.Variable | None = None,
         ) -> tuple[tf.Tensor | tf.Variable, ...]:
-            return kabsch_tf.horn_with_scale(P, Q)
+            return kabsch_tf.horn_with_scale(P, Q, weights=weights)
 
         def kabsch_rmsd(
-            self, P: tf.Tensor | tf.Variable, Q: tf.Tensor | tf.Variable
+            self,
+            P: tf.Tensor | tf.Variable,
+            Q: tf.Tensor | tf.Variable,
+            weights: tf.Tensor | tf.Variable | None = None,
         ) -> tf.Tensor | tf.Variable:
-            return kabsch_tf.kabsch_rmsd(P, Q)
+            return kabsch_tf.kabsch_rmsd(P, Q, weights=weights)
 
         def kabsch_umeyama_rmsd(
-            self, P: tf.Tensor | tf.Variable, Q: tf.Tensor | tf.Variable
+            self,
+            P: tf.Tensor | tf.Variable,
+            Q: tf.Tensor | tf.Variable,
+            weights: tf.Tensor | tf.Variable | None = None,
         ) -> tf.Tensor | tf.Variable:
-            return kabsch_tf.kabsch_umeyama_rmsd(P, Q)
+            return kabsch_tf.kabsch_umeyama_rmsd(P, Q, weights=weights)
 
         def is_nan(self, tensor: tf.Tensor | tf.Variable) -> bool:
             return tf.math.is_nan(tensor).numpy().any()
@@ -375,10 +431,7 @@ try:
             self,
             P: tf.Tensor | tf.Variable,
             Q: tf.Tensor | tf.Variable,
-            func: Callable[
-                [tf.Tensor | tf.Variable, tf.Tensor | tf.Variable],
-                tuple[tf.Tensor | tf.Variable, ...],
-            ],
+            func: Callable,
             seed: int | None = 42,
             wrt: str = "P",
         ) -> np.ndarray:
@@ -475,23 +528,35 @@ try:
                 ret = ret.astype(np.float32)
             return ret
 
-        def kabsch(self, P: mx.array, Q: mx.array) -> tuple[mx.array, ...]:
-            return kabsch_mlx.kabsch(P, Q)
+        def kabsch(
+            self, P: mx.array, Q: mx.array, weights: mx.array | None = None
+        ) -> tuple[mx.array, ...]:
+            return kabsch_mlx.kabsch(P, Q, weights=weights)
 
-        def kabsch_umeyama(self, P: mx.array, Q: mx.array) -> tuple[mx.array, ...]:
-            return kabsch_mlx.kabsch_umeyama(P, Q)
+        def kabsch_umeyama(
+            self, P: mx.array, Q: mx.array, weights: mx.array | None = None
+        ) -> tuple[mx.array, ...]:
+            return kabsch_mlx.kabsch_umeyama(P, Q, weights=weights)
 
-        def horn(self, P: mx.array, Q: mx.array) -> tuple[mx.array, ...]:
-            return kabsch_mlx.horn(P, Q)
+        def horn(
+            self, P: mx.array, Q: mx.array, weights: mx.array | None = None
+        ) -> tuple[mx.array, ...]:
+            return kabsch_mlx.horn(P, Q, weights=weights)
 
-        def horn_with_scale(self, P: mx.array, Q: mx.array) -> tuple[mx.array, ...]:
-            return kabsch_mlx.horn_with_scale(P, Q)
+        def horn_with_scale(
+            self, P: mx.array, Q: mx.array, weights: mx.array | None = None
+        ) -> tuple[mx.array, ...]:
+            return kabsch_mlx.horn_with_scale(P, Q, weights=weights)
 
-        def kabsch_rmsd(self, P: mx.array, Q: mx.array) -> mx.array:
-            return kabsch_mlx.kabsch_rmsd(P, Q)
+        def kabsch_rmsd(
+            self, P: mx.array, Q: mx.array, weights: mx.array | None = None
+        ) -> mx.array:
+            return kabsch_mlx.kabsch_rmsd(P, Q, weights=weights)
 
-        def kabsch_umeyama_rmsd(self, P: mx.array, Q: mx.array) -> mx.array:
-            return kabsch_mlx.kabsch_umeyama_rmsd(P, Q)
+        def kabsch_umeyama_rmsd(
+            self, P: mx.array, Q: mx.array, weights: mx.array | None = None
+        ) -> mx.array:
+            return kabsch_mlx.kabsch_umeyama_rmsd(P, Q, weights=weights)
 
         def is_nan(self, tensor: mx.array) -> bool:
             return mx.any(mx.isnan(tensor)).item()
@@ -500,7 +565,7 @@ try:
             self,
             P: mx.array,
             Q: mx.array,
-            func: Callable[[mx.array, mx.array], tuple[mx.array, ...]],
+            func: Callable,
             seed: int | None = 42,
             wrt: str = "P",
         ) -> np.ndarray:
@@ -570,17 +635,25 @@ class NumPyAdapter(FrameworkAdapter[np.ndarray]):
             obj = obj.astype(np.float32)
         return obj
 
-    def kabsch(self, P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, ...]:
-        return kabsch_np.kabsch(P, Q)
+    def kabsch(
+        self, P: np.ndarray, Q: np.ndarray, weights: np.ndarray | None = None
+    ) -> tuple[np.ndarray, ...]:
+        return kabsch_np.kabsch(P, Q, weights=weights)
 
-    def kabsch_umeyama(self, P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, ...]:
-        return kabsch_np.kabsch_umeyama(P, Q)
+    def kabsch_umeyama(
+        self, P: np.ndarray, Q: np.ndarray, weights: np.ndarray | None = None
+    ) -> tuple[np.ndarray, ...]:
+        return kabsch_np.kabsch_umeyama(P, Q, weights=weights)
 
-    def horn(self, P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, ...]:
-        return kabsch_np.horn(P, Q)
+    def horn(
+        self, P: np.ndarray, Q: np.ndarray, weights: np.ndarray | None = None
+    ) -> tuple[np.ndarray, ...]:
+        return kabsch_np.horn(P, Q, weights=weights)
 
-    def horn_with_scale(self, P: np.ndarray, Q: np.ndarray) -> tuple[np.ndarray, ...]:
-        return kabsch_np.horn_with_scale(P, Q)
+    def horn_with_scale(
+        self, P: np.ndarray, Q: np.ndarray, weights: np.ndarray | None = None
+    ) -> tuple[np.ndarray, ...]:
+        return kabsch_np.horn_with_scale(P, Q, weights=weights)
 
     def is_nan(self, tensor: np.ndarray) -> bool:
         return np.isnan(tensor).any()

--- a/tests/test_weighted.py
+++ b/tests/test_weighted.py
@@ -1,0 +1,414 @@
+"""Tests for per-point weighted alignment across all frameworks and algorithms."""
+
+import numpy as np
+import pytest
+from adapters import FrameworkAdapter, frameworks
+from conftest import ALGORITHMS, ALGORITHMS_3D_ONLY, ALGORITHMS_WITH_SCALE
+from utils import compute_numeric_grad
+
+
+def _get_transform_func(adapter, algo):
+    return adapter.get_transform_func(algo)
+
+
+def _call_algo(adapter, algo, P, Q, weights=None):
+    func = _get_transform_func(adapter, algo)
+    return func(P, Q, weights=weights)
+
+
+def _get_rotation(res, algo):
+    return res[0]
+
+
+def _get_translation(res, algo):
+    return res[1]
+
+
+def _get_rmsd(res, algo):
+    if algo in ALGORITHMS_WITH_SCALE:
+        return res[3]
+    return res[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(params=[2, 3, 4], ids=lambda x: f"{x}D")
+def dim(request) -> int:
+    return request.param
+
+
+@pytest.fixture
+def points_and_transform(dim):
+    """Generate source points P and target Q = R @ P + t with known transform."""
+    rng = np.random.default_rng(42)
+    n_points = max(10, dim * 2)
+    P = rng.random((n_points, dim))
+
+    # Random rotation (Haar measure via QR)
+    A = rng.normal(size=(dim, dim))
+    Q_mat, R_mat = np.linalg.qr(A)
+    d = np.diag(R_mat)
+    ph = d / np.abs(d)
+    rot = Q_mat * ph
+    if np.linalg.det(rot) < 0:
+        rot[:, 0] *= -1
+
+    t_true = rng.random((dim,)) * 5.0 - 2.5
+    Q = P @ rot.T + t_true
+    return P, Q, rot, t_true
+
+
+# ---------------------------------------------------------------------------
+# Test: uniform weights == no weights
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("adapter", frameworks, indirect=False)
+@pytest.mark.parametrize("algo", ALGORITHMS)
+class TestUniformWeightsEquivalence:
+    def test_uniform_ones(
+        self, adapter: FrameworkAdapter, algo, dim, points_and_transform
+    ):
+        """weights=ones(N) should produce identical results to weights=None."""
+        if not adapter.supports_dim(dim):
+            pytest.skip("Adapter does not support this dim")
+        if algo in ALGORITHMS_3D_ONLY and dim != 3:
+            pytest.skip("3D-only algorithm")
+
+        P_np, Q_np, _, _ = points_and_transform
+        P_fw = adapter.convert_in(P_np)
+        Q_fw = adapter.convert_in(Q_np)
+
+        w_np = np.ones(P_np.shape[0], dtype=np.float64)
+        w_fw = adapter.convert_in_with_dtype(w_np, adapter.precision)
+
+        res_no_w = _call_algo(adapter, algo, P_fw, Q_fw, weights=None)
+        res_w = _call_algo(adapter, algo, P_fw, Q_fw, weights=w_fw)
+
+        for t_no_w, t_w in zip(res_no_w, res_w, strict=False):
+            np.testing.assert_allclose(
+                adapter.convert_out(t_w),
+                adapter.convert_out(t_no_w),
+                atol=adapter.atol,
+                rtol=adapter.rtol,
+            )
+
+    def test_uniform_scaled(
+        self, adapter: FrameworkAdapter, algo, dim, points_and_transform
+    ):
+        """weights=k*ones(N) for arbitrary k>0 should match weights=None."""
+        if not adapter.supports_dim(dim):
+            pytest.skip("Adapter does not support this dim")
+        if algo in ALGORITHMS_3D_ONLY and dim != 3:
+            pytest.skip("3D-only algorithm")
+
+        P_np, Q_np, _, _ = points_and_transform
+        P_fw = adapter.convert_in(P_np)
+        Q_fw = adapter.convert_in(Q_np)
+
+        w_np = np.full(P_np.shape[0], 7.3, dtype=np.float64)
+        w_fw = adapter.convert_in_with_dtype(w_np, adapter.precision)
+
+        res_no_w = _call_algo(adapter, algo, P_fw, Q_fw, weights=None)
+        res_w = _call_algo(adapter, algo, P_fw, Q_fw, weights=w_fw)
+
+        for t_no_w, t_w in zip(res_no_w, res_w, strict=False):
+            np.testing.assert_allclose(
+                adapter.convert_out(t_w),
+                adapter.convert_out(t_no_w),
+                atol=adapter.atol,
+                rtol=adapter.rtol,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test: weight scaling invariance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("adapter", frameworks, indirect=False)
+@pytest.mark.parametrize("algo", ALGORITHMS)
+class TestWeightScalingInvariance:
+    def test_scaling_invariance(
+        self, adapter: FrameworkAdapter, algo, dim, points_and_transform
+    ):
+        """weights=w and weights=k*w should produce the same R, t, c."""
+        if not adapter.supports_dim(dim):
+            pytest.skip("Adapter does not support this dim")
+        if algo in ALGORITHMS_3D_ONLY and dim != 3:
+            pytest.skip("3D-only algorithm")
+
+        P_np, Q_np, _, _ = points_and_transform
+        P_fw = adapter.convert_in(P_np)
+        Q_fw = adapter.convert_in(Q_np)
+
+        rng = np.random.default_rng(123)
+        w_np = rng.random(P_np.shape[0]).astype(np.float64) + 0.1
+        w_fw = adapter.convert_in_with_dtype(w_np, adapter.precision)
+
+        w_scaled_np = w_np * 5.5
+        w_scaled_fw = adapter.convert_in_with_dtype(w_scaled_np, adapter.precision)
+
+        res_w = _call_algo(adapter, algo, P_fw, Q_fw, weights=w_fw)
+        res_ws = _call_algo(adapter, algo, P_fw, Q_fw, weights=w_scaled_fw)
+
+        for t_w, t_ws in zip(res_w, res_ws, strict=False):
+            np.testing.assert_allclose(
+                adapter.convert_out(t_ws),
+                adapter.convert_out(t_w),
+                atol=adapter.atol,
+                rtol=adapter.rtol,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test: zero-weight outlier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("adapter", frameworks, indirect=False)
+@pytest.mark.parametrize("algo", ALGORITHMS)
+class TestZeroWeightOutlier:
+    def test_zero_weight_outlier(
+        self, adapter: FrameworkAdapter, algo, dim, points_and_transform
+    ):
+        """Setting weight=0 on an outlier should recover the clean transform."""
+        if not adapter.supports_dim(dim):
+            pytest.skip("Adapter does not support this dim")
+        if algo in ALGORITHMS_3D_ONLY and dim != 3:
+            pytest.skip("3D-only algorithm")
+
+        P_np, Q_np, R_true, t_true = points_and_transform
+        n = P_np.shape[0]
+
+        # Add an outlier as the last point
+        outlier_P = np.array([100.0] * dim, dtype=np.float64)
+        outlier_Q = np.array([-100.0] * dim, dtype=np.float64)
+        P_with_outlier = np.vstack([P_np, outlier_P[np.newaxis, :]])
+        Q_with_outlier = np.vstack([Q_np, outlier_Q[np.newaxis, :]])
+
+        # Zero weight on the outlier
+        w_np = np.ones(n + 1, dtype=np.float64)
+        w_np[-1] = 0.0
+
+        P_fw = adapter.convert_in(P_with_outlier)
+        Q_fw = adapter.convert_in(Q_with_outlier)
+        w_fw = adapter.convert_in_with_dtype(w_np, adapter.precision)
+
+        res = _call_algo(adapter, algo, P_fw, Q_fw, weights=w_fw)
+
+        R_out = adapter.convert_out(res[0])
+        t_out = adapter.convert_out(res[1])
+
+        np.testing.assert_allclose(
+            R_out, R_true, atol=adapter.atol * 10, rtol=adapter.rtol * 10
+        )
+        np.testing.assert_allclose(
+            t_out, t_true, atol=adapter.atol * 10, rtol=adapter.rtol * 10
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: weighted RMSD manual check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("adapter", frameworks, indirect=False)
+@pytest.mark.parametrize("algo", ALGORITHMS)
+class TestWeightedRMSD:
+    def test_weighted_rmsd(
+        self, adapter: FrameworkAdapter, algo, dim, points_and_transform
+    ):
+        """Weighted RMSD should match manual computation."""
+        if not adapter.supports_dim(dim):
+            pytest.skip("Adapter does not support this dim")
+        if algo in ALGORITHMS_3D_ONLY and dim != 3:
+            pytest.skip("3D-only algorithm")
+
+        P_np, Q_np, _, _ = points_and_transform
+        rng = np.random.default_rng(99)
+        w_np = rng.random(P_np.shape[0]).astype(np.float64) + 0.1
+
+        P_fw = adapter.convert_in(P_np)
+        Q_fw = adapter.convert_in(Q_np)
+        w_fw = adapter.convert_in_with_dtype(w_np, adapter.precision)
+
+        res = _call_algo(adapter, algo, P_fw, Q_fw, weights=w_fw)
+        R_out = adapter.convert_out(res[0])
+        t_out = adapter.convert_out(res[1])
+        rmsd_out = float(adapter.convert_out(_get_rmsd(res, algo)))
+
+        if algo in ALGORITHMS_WITH_SCALE:
+            c_out = float(adapter.convert_out(res[2]))
+            aligned = c_out * (P_np @ R_out.T) + t_out
+        else:
+            aligned = P_np @ R_out.T + t_out
+
+        residual_sq = np.sum(np.square(aligned - Q_np), axis=-1)
+        w_sum = np.sum(w_np)
+        rmsd_manual = np.sqrt(np.sum(w_np * residual_sq) / w_sum)
+
+        np.testing.assert_allclose(
+            rmsd_out, rmsd_manual, atol=adapter.atol * 5, rtol=adapter.rtol * 5
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: validation errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("adapter", frameworks, indirect=False)
+class TestWeightValidation:
+    def test_negative_weight(self, adapter: FrameworkAdapter):
+        """Negative weights should raise ValueError."""
+        if not adapter.supports_dim(3):
+            pytest.skip("Adapter does not support dim=3")
+
+        rng = np.random.default_rng(42)
+        P_np = rng.random((5, 3))
+        Q_np = rng.random((5, 3))
+        w_np = np.array([1.0, -1.0, 1.0, 1.0, 1.0])
+
+        P_fw = adapter.convert_in(P_np)
+        Q_fw = adapter.convert_in(Q_np)
+        w_fw = adapter.convert_in_with_dtype(w_np, adapter.precision)
+
+        with pytest.raises((ValueError, Exception)):
+            adapter.kabsch(P_fw, Q_fw, weights=w_fw)
+
+    def test_all_zero_weights(self, adapter: FrameworkAdapter):
+        """All-zero weights should raise ValueError."""
+        if not adapter.supports_dim(3):
+            pytest.skip("Adapter does not support dim=3")
+
+        rng = np.random.default_rng(42)
+        P_np = rng.random((5, 3))
+        Q_np = rng.random((5, 3))
+        w_np = np.zeros(5)
+
+        P_fw = adapter.convert_in(P_np)
+        Q_fw = adapter.convert_in(Q_np)
+        w_fw = adapter.convert_in_with_dtype(w_np, adapter.precision)
+
+        with pytest.raises((ValueError, Exception)):
+            adapter.kabsch(P_fw, Q_fw, weights=w_fw)
+
+    def test_wrong_shape_weight(self, adapter: FrameworkAdapter):
+        """Wrong-shaped weights should raise ValueError."""
+        if not adapter.supports_dim(3):
+            pytest.skip("Adapter does not support dim=3")
+
+        rng = np.random.default_rng(42)
+        P_np = rng.random((5, 3))
+        Q_np = rng.random((5, 3))
+        w_np = np.ones(4)  # Wrong length
+
+        P_fw = adapter.convert_in(P_np)
+        Q_fw = adapter.convert_in(Q_np)
+        w_fw = adapter.convert_in_with_dtype(w_np, adapter.precision)
+
+        with pytest.raises((ValueError, Exception)):
+            adapter.kabsch(P_fw, Q_fw, weights=w_fw)
+
+
+# ---------------------------------------------------------------------------
+# Test: batched weights
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("adapter", frameworks, indirect=False)
+@pytest.mark.parametrize("algo", ALGORITHMS)
+class TestBatchedWeights:
+    def test_batched_weights(self, adapter: FrameworkAdapter, algo):
+        """Batched weights [B, N] with [B, N, D] point clouds."""
+        dim = 3
+        if not adapter.supports_dim(dim):
+            pytest.skip("Adapter does not support dim=3")
+        if algo in ALGORITHMS_3D_ONLY and dim != 3:
+            pytest.skip("3D-only algorithm")
+
+        rng = np.random.default_rng(42)
+        B, N = 3, 8
+        P_np = rng.random((B, N, dim))
+        Q_np = rng.random((B, N, dim))
+        w_np = rng.random((B, N)).astype(np.float64) + 0.1
+
+        P_fw = adapter.convert_in(P_np)
+        Q_fw = adapter.convert_in(Q_np)
+        w_fw = adapter.convert_in_with_dtype(w_np, adapter.precision)
+
+        res = _call_algo(adapter, algo, P_fw, Q_fw, weights=w_fw)
+
+        # Check output shapes
+        R_out = adapter.convert_out(res[0])
+        assert R_out.shape == (B, dim, dim)
+
+        # Compare with sequential per-batch computation
+        func = _get_transform_func(adapter, algo)
+        for b in range(B):
+            P_b = adapter.convert_in(P_np[b])
+            Q_b = adapter.convert_in(Q_np[b])
+            w_b = adapter.convert_in_with_dtype(w_np[b], adapter.precision)
+            res_b = func(P_b, Q_b, weights=w_b)
+
+            R_b = adapter.convert_out(res_b[0])
+            R_batch_b = adapter.convert_out(res[0])[b]
+            np.testing.assert_allclose(
+                R_batch_b, R_b, atol=adapter.atol, rtol=adapter.rtol
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test: gradient correctness for weighted alignment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("adapter", frameworks, indirect=False)
+@pytest.mark.parametrize("algo", ALGORITHMS)
+class TestWeightedGradient:
+    def test_weighted_gradient(self, adapter: FrameworkAdapter, algo):
+        """Analytical gradient with weights matches finite differences."""
+        if not adapter.supports_grad:
+            pytest.skip("Forward-only adapter")
+        dim = 3
+        if not adapter.supports_dim(dim):
+            pytest.skip("Adapter does not support dim=3")
+        if algo in ALGORITHMS_3D_ONLY and dim != 3:
+            pytest.skip("3D-only algorithm")
+        if adapter.precision in ("float16", "bfloat16"):
+            pytest.skip("Finite-difference gradient check unreliable at low precision")
+
+        rng = np.random.default_rng(42)
+        N = 8
+        P_np = rng.random((N, dim)).astype(np.float64)
+        Q_np = rng.random((N, dim)).astype(np.float64)
+        w_np = rng.random(N).astype(np.float64) + 0.1
+
+        w_fw = adapter.convert_in_with_dtype(w_np, adapter.precision)
+
+        # Create a weighted function for gradient computation
+        func_name = algo
+        base_func = adapter.get_transform_func(func_name)
+
+        def weighted_func(P, Q):
+            return base_func(P, Q, weights=w_fw)
+
+        P_fw = adapter.convert_in(P_np)
+        Q_fw = adapter.convert_in(Q_np)
+
+        grad_analytical = adapter.get_grad(P_fw, Q_fw, weighted_func, seed=42, wrt="P")
+
+        grad_numeric = compute_numeric_grad(
+            P_np, Q_np, adapter, weighted_func, seed=42, wrt="P"
+        )
+
+        np.testing.assert_allclose(
+            grad_analytical,
+            grad_numeric,
+            atol=adapter.atol * 10,
+            rtol=adapter.rtol * 10,
+        )

--- a/tests/test_weighted.py
+++ b/tests/test_weighted.py
@@ -16,14 +16,6 @@ def _call_algo(adapter, algo, P, Q, weights=None):
     return func(P, Q, weights=weights)
 
 
-def _get_rotation(res, algo):
-    return res[0]
-
-
-def _get_translation(res, algo):
-    return res[1]
-
-
 def _get_rmsd(res, algo):
     if algo in ALGORITHMS_WITH_SCALE:
         return res[3]
@@ -262,9 +254,10 @@ class TestWeightedRMSD:
 
 
 @pytest.mark.parametrize("adapter", frameworks, indirect=False)
+@pytest.mark.parametrize("algo", ALGORITHMS)
 class TestWeightValidation:
-    def test_negative_weight(self, adapter: FrameworkAdapter):
-        """Negative weights should raise ValueError."""
+    def test_negative_weight(self, adapter: FrameworkAdapter, algo):
+        """Negative weights should raise for all algorithms."""
         if not adapter.supports_dim(3):
             pytest.skip("Adapter does not support dim=3")
 
@@ -278,10 +271,10 @@ class TestWeightValidation:
         w_fw = adapter.convert_in_with_dtype(w_np, adapter.precision)
 
         with pytest.raises((ValueError, Exception)):
-            adapter.kabsch(P_fw, Q_fw, weights=w_fw)
+            _call_algo(adapter, algo, P_fw, Q_fw, weights=w_fw)
 
-    def test_all_zero_weights(self, adapter: FrameworkAdapter):
-        """All-zero weights should raise ValueError."""
+    def test_all_zero_weights(self, adapter: FrameworkAdapter, algo):
+        """All-zero weights should raise for all algorithms."""
         if not adapter.supports_dim(3):
             pytest.skip("Adapter does not support dim=3")
 
@@ -295,10 +288,10 @@ class TestWeightValidation:
         w_fw = adapter.convert_in_with_dtype(w_np, adapter.precision)
 
         with pytest.raises((ValueError, Exception)):
-            adapter.kabsch(P_fw, Q_fw, weights=w_fw)
+            _call_algo(adapter, algo, P_fw, Q_fw, weights=w_fw)
 
-    def test_wrong_shape_weight(self, adapter: FrameworkAdapter):
-        """Wrong-shaped weights should raise ValueError."""
+    def test_wrong_shape_weight(self, adapter: FrameworkAdapter, algo):
+        """Wrong-shaped weights should raise for all algorithms."""
         if not adapter.supports_dim(3):
             pytest.skip("Adapter does not support dim=3")
 
@@ -312,7 +305,7 @@ class TestWeightValidation:
         w_fw = adapter.convert_in_with_dtype(w_np, adapter.precision)
 
         with pytest.raises((ValueError, Exception)):
-            adapter.kabsch(P_fw, Q_fw, weights=w_fw)
+            _call_algo(adapter, algo, P_fw, Q_fw, weights=w_fw)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds optional `weights` parameter (`weights=None` default) to all 22 public alignment functions across NumPy, PyTorch, JAX, TensorFlow, and MLX
- When provided, computes weighted centroids, cross-covariance, variance, and RMSD using the weighted Procrustes formulation
- Fully backward compatible -- `weights=None` preserves existing behavior exactly
- SafeSVD/SafeEigh backward passes are unchanged; weights only affect what goes into the decomposition

Closes #159

## Changes

| File | Functions modified |
|------|-------------------|
| `numpy/kabsch_svd_nd.py` | `kabsch`, `kabsch_umeyama` |
| `numpy/horn_quat_3d.py` | `horn`, `horn_with_scale` |
| `pytorch/kabsch_svd_nd.py` | `kabsch`, `kabsch_umeyama`, `kabsch_rmsd`, `kabsch_umeyama_rmsd` |
| `pytorch/horn_quat_3d.py` | `horn`, `horn_with_scale` |
| `jax/kabsch_svd_nd.py` | `kabsch`, `kabsch_umeyama`, `kabsch_rmsd`, `kabsch_umeyama_rmsd` |
| `jax/horn_quat_3d.py` | `horn`, `horn_with_scale`, `_horn_core` |
| `tensorflow/kabsch_svd_nd.py` | `kabsch`, `kabsch_umeyama`, `kabsch_rmsd`, `kabsch_umeyama_rmsd` |
| `tensorflow/horn_quat_3d.py` | `horn`, `horn_with_scale` |
| `mlx/kabsch_svd_nd.py` | `kabsch`, `kabsch_umeyama`, `kabsch_rmsd`, `kabsch_umeyama_rmsd` |
| `mlx/horn_quat_3d.py` | `horn`, `horn_with_scale` |
| `tests/adapters.py` | All adapter methods updated to pass `weights` through |
| `tests/test_weighted.py` | **New** -- 462 tests |
| `README.md` | Added weighted usage example |

## Test plan

- [x] All 5400 existing tests pass (zero regressions)
- [x] 462 new weighted tests pass (8 skipped for float16/bfloat16 gradient FD checks)
- [x] Uniform weights equivalence (`ones(N)` and `k*ones(N)` match `None`)
- [x] Weight scaling invariance (`w` and `k*w` produce same R, t, c)
- [x] Zero-weight outlier recovery (weight=0 on outlier recovers clean transform)
- [x] Weighted RMSD matches manual computation
- [x] Validation errors (negative, all-zero, wrong shape)
- [x] Batched weights `[B, N]` with `[B, N, D]` point clouds
- [x] Gradient correctness (analytical vs finite differences) for all autodiff frameworks
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)