### PR TITLE
docs: fix consistency, missing content, and clarity across markdown files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,10 @@
+## Voice & Tone
+
+**Core principle**: Straightforward, honest, humble. Clear and engaging without jargon.
+
+- **NO EM DASHES** (the `—` character): Use double-hyphen `--` instead, or rephrase. Replace any em dashes you find.
+- **NO NEGATION/CONTRASTIVE REFRAMES**: Avoid "Not X, but Y" or "It's not just X, it's Y". Use direct, affirmative statements.
+  - *Bad*: "It's not just a model, it's a paradigm shift."
+  - *Good*: "This model introduces a new architecture."
+- **Be clear and concise**: Explain for a broad ML audience without overpromising, hyping, or using marketing speak.
+- **Support claims with evidence**: Share knowledge without arrogance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,13 +54,13 @@ The project uses `uv` for dependency management and task running. All dev depend
 - `tests/conftest.py` - Shared pytest fixtures (`dim`, `identity_points`, `known_transform_points`, `coplanar_points`, etc.) and a `pytest_collection_modifyitems` hook that filters out tests where the adapter's `supports_dim()` returns False (e.g., MLX only runs 3D tests).
 - `tests/utils.py` - `compute_numeric_grad` (finite-difference gradient checker) and `check_transform_close` helper.
 
-**Test files**: `test_forward_pass_equivalence.py`, `test_differentiability_traps.py`, `test_gradient_verification.py`, `test_catastrophic_cancellation.py`, `test_degeneracy.py`, `test_error_handling.py`.
+**Test files**: `test_forward_pass_equivalence.py`, `test_properties.py`, `test_differentiability_traps.py`, `test_gradient_verification.py`, `test_catastrophic_cancellation.py`, `test_degeneracy.py`, `test_error_handling.py`, `test_rmsd_wrappers.py`, `test_reference_validation.py`, `test_mixed_dtype.py`, `test_mlx_float64_warning.py`, `test_tf_dynamic_validation.py`.
 
 **JAX note**: `conftest.py` sets `JAX_ENABLE_X64=True` to allow float64. This must remain as the first env-var set before jax imports.
 
 ## Writing Style (for docs/comments)
 
 Per `.github/copilot-instructions.md`:
-- No em dashes (`--` is fine, `--` not `--`)
+- No em dashes (double-hyphen `--` is fine, em dash `—` is not)
 - No negation/contrastive reframes ("not X, but Y")
 - Clear and concise for a broad ML audience

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Open an issue on GitHub with:
 
 ## Pre-commit Hooks
 
-The repo ships a `.pre-commit-config.yaml` with three categories of hooks:
+The repo ships a `.pre-commit-config.yaml` with four categories of hooks:
 
 - **File hygiene** (`pre-commit-hooks`): strips trailing whitespace, ensures a
   final newline, normalizes line endings, and blocks large files or merge

--- a/README.md
+++ b/README.md
@@ -10,7 +10,21 @@ A collection of the Kabsch (SVD-based) and Horn (Quaternion-based) optimal struc
 
 ## Getting Started
 
-Copy the framework folder you need from `src/kabsch_horn/<framework>/` directly into your project. The code has no runtime dependencies beyond the framework itself, so nothing new gets added to your environment.
+### Install
+
+```bash
+pip install kabsch-horn-cookbook
+```
+
+Or with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv add kabsch-horn-cookbook
+```
+
+### Copy-the-folder
+
+Alternatively, copy the framework folder you need from `src/kabsch_horn/<framework>/` directly into your project. The code has no runtime dependencies beyond the framework itself, so nothing new gets added to your environment.
 
 ```
 src/kabsch_horn/
@@ -25,7 +39,7 @@ Each folder contains two files: `kabsch_svd_nd.py` for SVD-based alignment and `
 
 ## Usage
 
-Each framework exports a consistent API. Batch processing (`[Batch, Points, D]`) is supported for all functions.
+Each framework exports a consistent API. Batch processing (`[..., N, D]` with arbitrary leading dims) is supported for all functions.
 
 ```python
 import torch
@@ -109,7 +123,7 @@ JAX float64 requires `JAX_ENABLE_X64=True` to be set before importing JAX, other
 Traditionally used for 3D coordinates, this SVD implementation supports N-dimensional alignments. It scales to higher dimensions for tasks like mapping internal representations between models.
 
 ### Horn's Method (3D Quaternions)
-Horn's method applies strictly to 3D space. It uses a closed-form quaternion eigendecomposition to compute alignment and avoids the reflection trap often encountered in SVD approaches. This makes it a reliable choice for 3D point cloud tasks, such as molecular conformers or rigid-body physics.
+Horn's method applies strictly to 3D space. It uses a closed-form quaternion eigendecomposition to compute alignment. The quaternion formulation inherently produces proper rotations ($\det(R) = +1$) without a separate determinant correction step. This makes it a reliable choice for 3D point cloud tasks, such as molecular conformers or rigid-body physics.
 
 ## Stabilizing Gradients
 
@@ -239,6 +253,10 @@ The test suite is organized around mathematical claims rather than code coverage
 | [`tests/test_catastrophic_cancellation.py`](tests/test_catastrophic_cancellation.py) | Numerical stability at extreme coordinate magnitudes (1e-6 to 1e6) |
 | [`tests/test_error_handling.py`](tests/test_error_handling.py) | Correct exceptions for mismatched shapes, wrong dimensions, and invalid inputs |
 | [`tests/test_rmsd_wrappers.py`](tests/test_rmsd_wrappers.py) | `kabsch_rmsd` and `kabsch_umeyama_rmsd` match full-call RMSD output; N=1 single-point edge cases |
+| [`tests/test_reference_validation.py`](tests/test_reference_validation.py) | Cross-framework validation against NumPy reference outputs over multiple seeds |
+| [`tests/test_mixed_dtype.py`](tests/test_mixed_dtype.py) | Correct behavior when P and Q have different dtypes |
+| [`tests/test_mlx_float64_warning.py`](tests/test_mlx_float64_warning.py) | MLX emits a warning when float64 silently falls back to CPU |
+| [`tests/test_tf_dynamic_validation.py`](tests/test_tf_dynamic_validation.py) | TensorFlow runtime shape validation for dynamic shapes |
 
 The suite runs across 4 frameworks x 4 precisions (float16, bfloat16, float32, float64), with MLX restricted to 3D. Hypothesis property tests use configurable example counts; CI runs the defaults.
 

--- a/docs/algorithms/index.md
+++ b/docs/algorithms/index.md
@@ -24,7 +24,7 @@ The Umeyama extension adds a global scale factor \(c\) computed from the ratio o
 
 ### Horn's method (3D quaternions)
 
-Horn's method applies strictly to 3D. It constructs a 4x4 symmetric matrix from the cross-covariance and finds the eigenvector corresponding to the largest eigenvalue. This eigenvector is a unit quaternion representing the optimal rotation. The closed-form quaternion approach avoids the reflection trap that SVD methods must handle with a determinant sign correction.
+Horn's method applies strictly to 3D. It constructs a 4x4 symmetric matrix from the cross-covariance and finds the eigenvector corresponding to the largest eigenvalue. This eigenvector is a unit quaternion representing the optimal rotation. The quaternion formulation inherently produces proper rotations (\(\det(R) = +1\)) without a separate determinant correction step.
 
 ## Stabilizing gradients
 
@@ -32,7 +32,7 @@ Point cloud alignments during neural network training often encounter degenerate
 
 ### SafeSVD and SafeEigh
 
-The autograd wrappers for PyTorch, JAX, TensorFlow, and MLX override the standard backward pass. During backpropagation, they mask near-zero differences between singular values (or eigenvalues) with \(\varepsilon = \text{finfo}(\text{dtype}).\text{eps}\):
+The autograd wrappers for PyTorch, JAX, TensorFlow, and MLX override the standard backward pass. During backpropagation, they zero out gradient terms where the difference between singular values (or eigenvalues) falls below \(\varepsilon = \text{finfo}(\text{dtype}).\text{eps}\):
 
 \[
 \frac{1}{\sigma_i - \sigma_j} \rightarrow \begin{cases} \frac{1}{\sigma_i - \sigma_j} & \text{if } |\sigma_i - \sigma_j| > \varepsilon \\ 0 & \text{otherwise} \end{cases}

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -24,8 +24,8 @@ All frameworks share the same function signatures and return types. Pick the pag
 
 **RMSD loss functions** (autodiff frameworks only):
 
-- `kabsch_rmsd(P, Q)` returns RMSD scalar(s) with stable gradients
-- `kabsch_umeyama_rmsd(P, Q)` returns RMSD scalar(s) with stable gradients
+- `kabsch_rmsd(P, Q)` returns RMSD `[...]` with stable gradients
+- `kabsch_umeyama_rmsd(P, Q)` returns RMSD `[...]` with stable gradients
 
 ## Framework pages
 

--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -1,6 +1,7 @@
 # Benchmarks
 
-Performance comparisons across frameworks, dimensions, and batch sizes. Coming soon.
+!!! note "Under construction"
+    Benchmarks are planned for a future release.
 
 **Planned comparisons:**
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,6 +1,7 @@
 # Guides
 
-Tutorials and recipes for common alignment tasks. Coming soon.
+!!! note "Under construction"
+    These guides are planned for a future release.
 
 **Planned topics:**
 
@@ -8,3 +9,5 @@ Tutorials and recipes for common alignment tasks. Coming soon.
 - Representation matching in high-dimensional spaces
 - Molecular conformer alignment workflows
 - Integrating with training loops (PyTorch Lightning, Flax, Keras)
+
+In the meantime, see the [Getting Started](../getting-started/index.md) quickstart and the [README](https://github.com/hunter-heidenreich/Kabsch-Cookbook#extending-the-cookbook) for usage examples.


### PR DESCRIPTION
## Summary

- **README**: Add pip/uv install instructions to Getting Started, fix `[Batch, Points, D]` → `[..., N, D]` shape notation, add 4 missing test files to the testing table, rewrite Horn description to remove contrastive phrasing per writing style guide
- **CONTRIBUTING**: Fix "three categories" → "four categories" for pre-commit hooks (there are four bullet points)
- **CLAUDE.md**: Update stale test file list from 6 to all 12 test files, clarify ambiguous em dash rule
- **copilot-instructions.md**: Clarify em dash rule with explicit character names
- **docs/api/index.md**: Replace vague "RMSD scalar(s)" with `[...]` shape notation matching the README
- **docs/algorithms/index.md**: Clarify SafeSVD masking prose (masking to zero, not replacing with epsilon), rewrite Horn description
- **docs/guides, docs/benchmarks**: Replace bare "Coming soon" text with MkDocs admonition blocks and a cross-link

## Test plan

- [ ] No code changes -- markdown only
- [ ] Verify MkDocs builds locally (`uv run mkdocs build`) if docs site is set up
- [ ] Spot-check that README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)