### PR TITLE
docs: document per-point weights across all markdown files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ The project uses `uv` for dependency management and task running. All dev depend
 
 **Tensor conventions**:
 - Input shape: `[N, D]` (single) or `[..., N, D]` (batched, arbitrary leading dims)
+- All alignment functions accept an optional `weights: [..., N]` parameter for per-point weighting
 - `kabsch`/`horn` return `(R, t, rmsd)` where `R: [..., D, D]`, `t: [..., D]`, `rmsd: [...]`
 - `kabsch_umeyama`/`horn_with_scale` return `(R, t, c, rmsd)` with scale `c: [...]`
 - MLX adapter is restricted to `dim == 3` (hardcoded 3x3 determinant correction)
@@ -54,7 +55,7 @@ The project uses `uv` for dependency management and task running. All dev depend
 - `tests/conftest.py` - Shared pytest fixtures (`dim`, `identity_points`, `known_transform_points`, `coplanar_points`, etc.) and a `pytest_collection_modifyitems` hook that filters out tests where the adapter's `supports_dim()` returns False (e.g., MLX only runs 3D tests).
 - `tests/utils.py` - `compute_numeric_grad` (finite-difference gradient checker) and `check_transform_close` helper.
 
-**Test files**: `test_forward_pass_equivalence.py`, `test_properties.py`, `test_differentiability_traps.py`, `test_gradient_verification.py`, `test_catastrophic_cancellation.py`, `test_degeneracy.py`, `test_error_handling.py`, `test_rmsd_wrappers.py`, `test_reference_validation.py`, `test_mixed_dtype.py`, `test_mlx_float64_warning.py`, `test_tf_dynamic_validation.py`.
+**Test files**: `test_forward_pass_equivalence.py`, `test_properties.py`, `test_differentiability_traps.py`, `test_gradient_verification.py`, `test_catastrophic_cancellation.py`, `test_degeneracy.py`, `test_error_handling.py`, `test_rmsd_wrappers.py`, `test_reference_validation.py`, `test_mixed_dtype.py`, `test_mlx_float64_warning.py`, `test_tf_dynamic_validation.py`, `test_weighted.py`.
 
 **JAX note**: `conftest.py` sets `JAX_ENABLE_X64=True` to allow float64. This must remain as the first env-var set before jax imports.
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ The test suite is organized around mathematical claims rather than code coverage
 | [`tests/test_mixed_dtype.py`](tests/test_mixed_dtype.py) | Correct behavior when P and Q have different dtypes |
 | [`tests/test_mlx_float64_warning.py`](tests/test_mlx_float64_warning.py) | MLX emits a warning when float64 silently falls back to CPU |
 | [`tests/test_tf_dynamic_validation.py`](tests/test_tf_dynamic_validation.py) | TensorFlow runtime shape validation for dynamic shapes |
+| [`tests/test_weighted.py`](tests/test_weighted.py) | Per-point weighted alignment: uniform equivalence, outlier downweighting, gradient stability, error handling, and batching |
 
 The suite runs across 4 frameworks x 4 precisions (float16, bfloat16, float32, float64), with MLX restricted to 3D. Hypothesis property tests use configurable example counts; CI runs the defaults.
 

--- a/docs/algorithms/index.md
+++ b/docs/algorithms/index.md
@@ -8,11 +8,13 @@ Given two point clouds \(P\) and \(Q\) with \(N\) points in \(D\) dimensions, th
 \text{RMSD} = \sqrt{\frac{1}{N} \sum_{i=1}^{N} \| c \cdot R p_i + t - q_i \|^2}
 \]
 
+All functions accept an optional per-point weight vector \(w \in \mathbb{R}^N\) (\(w_i \geq 0\), \(\sum w_i > 0\)). When weights are provided, centroids become weighted means and the RMSD uses the weighted sum of squared residuals. Uniform weights recover the standard unweighted formulation.
+
 This library provides two algorithms for solving this problem.
 
 ### Kabsch algorithm (N-dimensional SVD)
 
-The Kabsch algorithm works in any number of dimensions. It centers both clouds, computes the cross-covariance matrix \(H = (P - \bar{P})^\top (Q - \bar{Q})\), and takes the SVD:
+The Kabsch algorithm works in any number of dimensions. It centers both clouds (using weighted means when weights are provided), computes the cross-covariance matrix \(H = (P - \bar{P})^\top (Q - \bar{Q})\), and takes the SVD:
 
 \[
 H = U \Sigma V^\top

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -15,17 +15,24 @@ All frameworks share the same function signatures and return types. Pick the pag
 
 ## Common signatures
 
-**Alignment functions** accept `P` and `Q` tensors of shape `[N, D]` (single) or `[..., N, D]` (batched).
+**Alignment functions** accept `P` and `Q` tensors of shape `[N, D]` (single) or `[..., N, D]` (batched). All alignment functions accept an optional `weights` parameter of shape `[..., N]` for per-point weighting.
 
-- `kabsch(P, Q)` returns `(R, t, rmsd)` -- rotation `[..., D, D]`, translation `[..., D]`, RMSD `[...]`
-- `kabsch_umeyama(P, Q)` returns `(R, t, c, rmsd)` -- adds scale `c: [...]`
-- `horn(P, Q)` returns `(R, t, rmsd)` -- 3D only
-- `horn_with_scale(P, Q)` returns `(R, t, c, rmsd)` -- 3D only
+- `kabsch(P, Q, weights=None)` returns `(R, t, rmsd)` -- rotation `[..., D, D]`, translation `[..., D]`, RMSD `[...]`
+- `kabsch_umeyama(P, Q, weights=None)` returns `(R, t, c, rmsd)` -- adds scale `c: [...]`
+- `horn(P, Q, weights=None)` returns `(R, t, rmsd)` -- 3D only
+- `horn_with_scale(P, Q, weights=None)` returns `(R, t, c, rmsd)` -- 3D only
 
 **RMSD loss functions** (autodiff frameworks only):
 
-- `kabsch_rmsd(P, Q)` returns RMSD `[...]` with stable gradients
-- `kabsch_umeyama_rmsd(P, Q)` returns RMSD `[...]` with stable gradients
+- `kabsch_rmsd(P, Q, weights=None)` returns RMSD `[...]` with stable gradients
+- `kabsch_umeyama_rmsd(P, Q, weights=None)` returns RMSD `[...]` with stable gradients
+
+**Weights parameter:**
+
+- Shape: `[..., N]` -- one weight per point, matching the batch and point dimensions of `P` and `Q`
+- Must be non-negative and sum to a positive value along the points axis
+- When `None` (default), all points are weighted equally
+- When provided, centroids and RMSD use weighted means
 
 ## Framework pages
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -64,6 +64,16 @@ R, t, rmsd = kh.horn(P_3d, Q_3d)
 R, t, c, rmsd = kh.horn_with_scale(P_3d, Q_3d)
 ```
 
+### Per-point weights
+
+All alignment functions accept an optional `weights` parameter of shape `[..., N]`. Weights must be non-negative and sum to a positive value.
+
+```python
+# Confidence scores, B-factors, attention masks, etc.
+weights = torch.rand(10, 100)  # shape: [..., N]
+R, t, rmsd = kh.kabsch(P, Q, weights=weights)
+```
+
 ### RMSD loss for training
 
 Autodiff frameworks export single-call RMSD loss functions with stable gradients:

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,10 @@ Q = torch.randn(10, 100, 3)
 # Kabsch alignment
 R, t, rmsd = kh.kabsch(P, Q)
 
+# Per-point weights (e.g., confidence scores, B-factors)
+weights = torch.rand(10, 100)
+R, t, rmsd = kh.kabsch(P, Q, weights=weights)
+
 # Single-call RMSD loss for training
 loss = kh.kabsch_rmsd(P, Q)
 loss.mean().backward()


### PR DESCRIPTION
## Summary

Documents the per-point `weights` parameter (#159) across all markdown documentation:

- **README**: Add `test_weighted.py` to the testing table
- **CLAUDE.md**: Add `weights` to tensor conventions, add `test_weighted.py` to test file list
- **docs/api/index.md**: Add `weights=None` to all function signatures, add weights parameter section describing shape, constraints, and behavior
- **docs/getting-started/index.md**: Add per-point weights quickstart section with code example
- **docs/algorithms/index.md**: Note weighted formulation in the problem statement and Kabsch algorithm description
- **docs/index.md**: Add weights example to the landing page quick example

## Test plan

- [ ] No code changes -- markdown only
- [ ] Verify MkDocs builds locally (`uv run mkdocs build`) if docs site is set up
- [ ] Confirm `weights` parameter description matches actual API signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)