### PR TITLE
docs: correct install instructions to git-based (not on PyPI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,16 @@ A collection of the Kabsch (SVD-based) and Horn (Quaternion-based) optimal struc
 
 ### Install
 
+This is a reference cookbook, meant to be read and copied (see [Copy-the-folder](#copy-the-folder) below). If you would rather depend on it directly, install a pinned version from GitHub:
+
 ```bash
-pip install kabsch-horn-cookbook
+pip install "git+https://github.com/hunter-heidenreich/Kabsch-Cookbook.git@v0.4.0"
 ```
 
 Or with [uv](https://docs.astral.sh/uv/):
 
 ```bash
-uv add kabsch-horn-cookbook
+uv add "git+https://github.com/hunter-heidenreich/Kabsch-Cookbook.git@v0.4.0"
 ```
 
 ### Copy-the-folder

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -2,16 +2,18 @@
 
 ## Installation
 
+This is a reference cookbook, meant to be read and copied (see [Copy-the-folder](#copy-the-folder) below). If you would rather depend on it directly, install a pinned version from GitHub.
+
 ### pip
 
 ```bash
-pip install kabsch-horn-cookbook
+pip install "git+https://github.com/hunter-heidenreich/Kabsch-Cookbook.git@v0.4.0"
 ```
 
 ### uv
 
 ```bash
-uv add kabsch-horn-cookbook
+uv add "git+https://github.com/hunter-heidenreich/Kabsch-Cookbook.git@v0.4.0"
 ```
 
 ### Copy-the-folder


### PR DESCRIPTION
## What

The README and docs site told users to `pip install kabsch-horn-cookbook` / `uv add kabsch-horn-cookbook`, but the package is **not published to PyPI** (the name 404s), so neither command resolves.

This corrects both the README and `docs/getting-started/index.md` to:

- Point at a **pinned git install** (`pip install "git+https://github.com/hunter-heidenreich/Kabsch-Cookbook.git@v0.4.0"`), which actually works now that `v0.4.0` is a real release/tag.
- Lead with the **copy-the-folder** reference-cookbook framing, which is the intended way to consume this code (zero runtime deps, MIT, per-framework self-contained folders).

## Why

This is a reference cookbook, not a published dependency. The install instructions should match reality. Publishing to PyPI is intentionally out of scope: the artifact is meant to be read and copied, and a pinned git install covers the rare "depend on it directly" case with full reproducibility.

## Notes

- `v0.4.0` was tagged/released to close a gap where `pyproject`/CHANGELOG read `0.4.0` but no `v0.4.0` tag had been cut (release-please bumped the version but never created the release).
- Docs-only change; no code touched. Test suite is green on `main` (5490 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)