### PR TITLE
docs: cross-link README to companion writeups and paper notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,9 +273,18 @@ Run the test suite with:
 uv run pytest tests/
 ```
 
+## Further Reading
+
+* **[The Kabsch Algorithm](https://hunterheidenreich.com/posts/kabsch-algorithm/)** -- a step-by-step derivation of the math, with from-scratch differentiable implementations in NumPy, PyTorch, TensorFlow, and JAX.
+* **[Project overview](https://hunterheidenreich.com/projects/kabsch-horn-cookbook/)** -- background, design notes, and worked examples for this library.
+
 ## References
 
-* **[Kabsch 1976]** Kabsch, W. (1976). "A solution for the best rotation to relate two sets of vectors."
-* **[Kabsch 1978]** Kabsch, W. (1978). "A discussion of the solution for the best rotation to relate two sets of vectors."
-* **[Horn 1987]** Horn, B.K.P. (1987). "Closed-form solution of absolute orientation using unit quaternions."
-* **[Umeyama 1991]** Umeyama, S. (1991). "Least-squares estimation of transformation parameters between two point patterns."
+Each foundational paper has a detailed walkthrough in the [companion notes](https://hunterheidenreich.com/notes/biology/computational-biology/).
+
+* **[Kabsch 1976]** Kabsch, W. (1976). "A solution for the best rotation to relate two sets of vectors." *Acta Crystallographica A*. [[notes](https://hunterheidenreich.com/notes/biology/computational-biology/kabsch-algorithm/)]
+* **[Kabsch 1978]** Kabsch, W. (1978). "A discussion of the solution for the best rotation to relate two sets of vectors." *Acta Crystallographica A*.
+* **[Arun 1987]** Arun, K.S., Huang, T.S., & Blostein, S.D. (1987). "Least-squares fitting of two 3-D point sets." *IEEE TPAMI*. [[notes](https://hunterheidenreich.com/notes/biology/computational-biology/arun-svd-point-fitting/)]
+* **[Horn 1987]** Horn, B.K.P. (1987). "Closed-form solution of absolute orientation using unit quaternions." *JOSA A*. [[notes](https://hunterheidenreich.com/notes/biology/computational-biology/horn-absolute-orientation/)]
+* **[Horn 1988]** Horn, B.K.P., Hilden, H.M., & Negahdaripour, S. (1988). "Closed-form solution of absolute orientation using orthonormal matrices." *JOSA A*. [[notes](https://hunterheidenreich.com/notes/biology/computational-biology/horn-orthonormal-matrices/)]
+* **[Umeyama 1991]** Umeyama, S. (1991). "Least-squares estimation of transformation parameters between two point patterns." *IEEE TPAMI*. [[notes](https://hunterheidenreich.com/notes/biology/computational-biology/umeyama-similarity-transformation/)]


### PR DESCRIPTION
## What

The README had **no outbound links** to the deeper material that exists for this work, so a reader landing on the repo (the common entry point) had no path to it. This adds:

- A **Further Reading** section: the [blog walkthrough](https://hunterheidenreich.com/posts/kabsch-algorithm/) (full math derivation + from-scratch implementations) and the [project overview](https://hunterheidenreich.com/projects/kabsch-horn-cookbook/).
- **Linked references**: each foundational paper now links to its detailed companion note, and the **Arun 1987** and **Horn 1988** references the algorithms build on were added (previously missing).

## Why

The repo, the blog, the project page, and the paper notes should form a connected web; the README was the one node with no edges out. This closes that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)