### PR TITLE
docs: bump pinned install to v0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ A collection of the Kabsch (SVD-based) and Horn (Quaternion-based) optimal struc
 This is a reference cookbook, meant to be read and copied (see [Copy-the-folder](#copy-the-folder) below). If you would rather depend on it directly, install a pinned version from GitHub:
 
 ```bash
-pip install "git+https://github.com/hunter-heidenreich/Kabsch-Cookbook.git@v0.4.0"
+pip install "git+https://github.com/hunter-heidenreich/Kabsch-Cookbook.git@v0.4.1"
 ```
 
 Or with [uv](https://docs.astral.sh/uv/):
 
 ```bash
-uv add "git+https://github.com/hunter-heidenreich/Kabsch-Cookbook.git@v0.4.0"
+uv add "git+https://github.com/hunter-heidenreich/Kabsch-Cookbook.git@v0.4.1"
 ```
 
 ### Copy-the-folder

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -7,13 +7,13 @@ This is a reference cookbook, meant to be read and copied (see [Copy-the-folder]
 ### pip
 
 ```bash
-pip install "git+https://github.com/hunter-heidenreich/Kabsch-Cookbook.git@v0.4.0"
+pip install "git+https://github.com/hunter-heidenreich/Kabsch-Cookbook.git@v0.4.1"
 ```
 
 ### uv
 
 ```bash
-uv add "git+https://github.com/hunter-heidenreich/Kabsch-Cookbook.git@v0.4.0"
+uv add "git+https://github.com/hunter-heidenreich/Kabsch-Cookbook.git@v0.4.1"
 ```
 
 ### Copy-the-folder


### PR DESCRIPTION
Points the README and docs-site install instructions at the latest release (`@v0.4.1`).

Note: a hardcoded version pin inherently lags by one release under release-please (this doc-bump commit itself becomes the next release). Fine to leave the resulting release PR open until there's more to ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)